### PR TITLE
changed factorial to reciprocal and keypad change

### DIFF
--- a/data/main.ui
+++ b/data/main.ui
@@ -2187,19 +2187,19 @@ On: 1.1 * 1.1 ≈ 1.2</property>
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkButton" id="button_factorial">
+                                  <object class="GtkButton" id="button_reciprocal">
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="focus_on_click">False</property>
                                     <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Factorial</property>
+                                    <property name="tooltip_text" translatable="yes">Reciprocal</property>
                                     <property name="use_underline">True</property>
-                                    <signal name="clicked" handler="on_button_factorial_clicked" swapped="no"/>
+                                    <signal name="clicked" handler="on_button_reciprocal_clicked" swapped="no"/>
                                     <child>
                                       <object class="GtkLabel">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
-                                        <property name="label" translatable="yes">x!</property>
+                                        <property name="label" translatable="yes">1/x</property>
                                       </object>
                                     </child>
                                   </object>

--- a/src/callbacks.cc
+++ b/src/callbacks.cc
@@ -8861,13 +8861,26 @@ void new_vector(GtkMenuItem*, gpointer)
 	edit_matrix(_("Vectors"), NULL, NULL, GTK_WIDGET(gtk_builder_get_object(main_builder, "main_window")), TRUE);
 }
 
+bool is_number(const gchar *str) {
+	while (*str) {
+		if ((*str < '0' || *str > '9') && *str != '.') return false;
+		str++;
+	}
+	return true;
+}
+
 /*
 	insert one-argument function when button clicked
 */
 void insertButtonFunction(const gchar *text, bool append_space = true) {
 	gint start = 0, end = 0;
+	const gchar *expr = gtk_entry_get_text(GTK_ENTRY(expression));
+	int old_length = g_utf8_strlen(expr, -1);
+	// special case: the user just entered a number, then select all, so that it gets executed
+	if (is_number(expr)) {
+		gtk_editable_select_region(GTK_EDITABLE(expression), 0, old_length);
+	}
 	if(gtk_editable_get_selection_bounds(GTK_EDITABLE(expression), &start, &end)) {
-		int old_length = gtk_entry_get_text_length(GTK_ENTRY(expression));
 		//set selection as argument
 		gchar *gstr = gtk_editable_get_chars(GTK_EDITABLE(expression), start, end);
 		gchar *gstr2 = g_strdup_printf("%s(%s)", text, gstr);

--- a/src/callbacks.cc
+++ b/src/callbacks.cc
@@ -8867,10 +8867,15 @@ void new_vector(GtkMenuItem*, gpointer)
 void insertButtonFunction(const gchar *text, bool append_space = true) {
 	gint start = 0, end = 0;
 	if(gtk_editable_get_selection_bounds(GTK_EDITABLE(expression), &start, &end)) {
+		int old_length = gtk_entry_get_text_length(GTK_ENTRY(expression));
 		//set selection as argument
 		gchar *gstr = gtk_editable_get_chars(GTK_EDITABLE(expression), start, end);
 		gchar *gstr2 = g_strdup_printf("%s(%s)", text, gstr);
 		insert_text(gstr2);
+		// execute expression, if the whole expression was selected, no need for additional enter
+		if (end - start == old_length) {
+			execute_expression();
+		}
 		g_free(gstr);
 		g_free(gstr2);
 	} else {
@@ -11446,13 +11451,8 @@ void on_button_mod_clicked(GtkButton*, gpointer) {
 	insertButtonFunction(CALCULATOR->f_mod);
 }
 
-void on_button_factorial_clicked(GtkButton*, gpointer) {
-	if(rpn_mode) {
-		insertButtonFunction(CALCULATOR->f_factorial);
-		return;
-	}
-	wrap_expression_selection();
-	insert_text("!");
+void on_button_reciprocal_clicked(GtkButton*, gpointer) {
+	insertButtonFunction("inv");
 }
 
 /*

--- a/src/callbacks.h
+++ b/src/callbacks.h
@@ -261,7 +261,7 @@ void on_button_sine_clicked(GtkButton *w, gpointer user_data);
 void on_button_cosine_clicked(GtkButton *w, gpointer user_data);
 void on_button_store_clicked(GtkButton *w, gpointer user_data);
 void on_button_mod_clicked(GtkButton *w, gpointer user_data);
-void on_button_factorial_clicked(GtkButton *w, gpointer user_data);
+void on_button_reciprocal_clicked(GtkButton *w, gpointer user_data);
 void on_togglebutton_expression_toggled(GtkToggleButton *togglebutton, gpointer user_data);
 void on_togglebutton_result_toggled(GtkToggleButton *togglebutton, gpointer user_data);
 void on_expression_changed(GtkEditable *w, gpointer user_data);


### PR DESCRIPTION
I think most people need the reciprocal function more often than the factorial function. This pull request changes this.

Another change: now it is faster to use it like a normal calculator for single argument functions, no need to hit the enter key again. Example of the old behaviour (brackets are used for buttons and the enter key) :

1+2 [cos] [enter]

New behaviour:

1 + 2 [cos]

The result is only calculated, if the full expression was selected, otherwise it is the old behaviour, that the function is only inserted, in case you want to insert more.

The last different to a "normal" calculator is fixed with the second commit: if you enter "90 [sin]" on a normal calculator, it calculates the result. With Qalculate you had to enter "[sin] 90"
Still a minor difference to a normal calculator: If you enter "10 [cos]", it doesn't work, you have to enter "[cos] 10 [enter]". This is fixed now, you can enter "10 [cos]" and it shows the result.

Note that I don't have experience with GTK, so maybe take a look at it if the code looks good, and then accept the pull request, if you like the changes. And I didn't check it in RPN mode, and maybe there are other side effects for it which I'm not aware of, but at least works for me, now I can use it as a replacement for kcalc.

Maybe would be a good idea to allow to configure the keys, or some spare keys? A user could then configure a factorial key, if needed, or any other function.