### PR TITLE
Fixed some spelling mistakes in the Swedish translation

### DIFF
--- a/po/sv.po
+++ b/po/sv.po
@@ -421,7 +421,7 @@ msgstr "Egenskaper"
 
 #: ../data/datasetedit.ui.h:35
 msgid "Name used to invoke the function in expressions"
-msgstr "Namn som används för referera till funktionen i uttryck"
+msgstr "Namn som används för att referera till funktionen i uttryck"
 
 #: ../data/datasetedit.ui.h:36
 msgid "Object argument name"
@@ -487,7 +487,7 @@ msgstr "Redigera valt dataobjekt"
 
 #: ../data/datasets.ui.h:15
 msgid "Remove the selected data object"
-msgstr "Ta bort valt dataobject"
+msgstr "Ta bort valt dataobjekt"
 
 #: ../data/datasets.ui.h:16
 msgid "Data Set Description"
@@ -551,7 +551,7 @@ msgstr "Godta skapande/modifiering av funktionen"
 
 #: ../data/functionedit.ui.h:8
 msgid "Name used to invoke this function in expressions"
-msgstr "Namn som används för referera till funktionen i uttryck"
+msgstr "Namn som används för att referera till funktionen i uttryck"
 
 #: ../data/functionedit.ui.h:12
 msgid "Title displayed in menus and in function manager"
@@ -868,7 +868,7 @@ msgstr "Hämta nuvarande växelkurser från internet"
 
 #: ../data/main.ui.h:32
 msgid "Update Exchange Rates"
-msgstr "Updatera växelkurser"
+msgstr "Uppdatera växelkurser"
 
 #: ../data/main.ui.h:33
 msgid "Plot Functions/Data"
@@ -1064,7 +1064,7 @@ msgstr ""
 
 #: ../data/main.ui.h:82
 msgid "Round Halfway Numbers to Even"
-msgstr "Avrunda mittimellan-tal till jämn siffra"
+msgstr "Avrunda mittemellan-tal till jämn siffra"
 
 #: ../data/main.ui.h:83
 msgid ""
@@ -1268,7 +1268,7 @@ msgstr "Förkorta namn"
 
 #: ../data/main.ui.h:131
 msgid "Enabled Objects"
-msgstr "Aktiverade object"
+msgstr "Aktiverade objekt"
 
 #: ../data/main.ui.h:132 ../data/variables.ui.h:1
 msgid "Variables"
@@ -1304,7 +1304,7 @@ msgstr "Tillåt complext resultat"
 
 #: ../data/main.ui.h:141
 msgid "Disables/enables infinite numbers in result"
-msgstr "(Av)aktiverar oöndliga tal i resultat"
+msgstr "(Av)aktiverar oändliga tal i resultat"
 
 #: ../data/main.ui.h:142
 msgid "Allow Infinite Result"
@@ -1798,7 +1798,7 @@ msgstr "Addera valda värden"
 
 #: ../data/main.ui.h:267
 msgid "Subtract the selected value(s)"
-msgstr "Subtrahera vala värdeen"
+msgstr "Subtrahera valda värden"
 
 #: ../data/main.ui.h:268
 msgid "Multiply the the selected value(s)"
@@ -2481,7 +2481,7 @@ msgstr "Spara programläge vid avslut"
 
 #: ../data/preferences.ui.h:3
 msgid "If the mode of the calculator shall be restored"
-msgstr "Huruvida kalkulatorns läge skall återskapas"
+msgstr "Huruvida kalkylatorns läge skall återskapas"
 
 #: ../data/preferences.ui.h:4
 msgid "Save definitions on exit"
@@ -2528,12 +2528,12 @@ msgstr "Om uttrycksstatus skall visas under uttrycksfältet medans text skrivs"
 
 #: ../data/preferences.ui.h:13
 msgid "Use keyboard keys for RPN"
-msgstr "Använd tangenbordet för RPN"
+msgstr "Använd tangentbordet för RPN"
 
 #: ../data/preferences.ui.h:14
 msgid "Use keyboard operator keys for RPN operations (+-*/^)."
 msgstr ""
-"Använd tangenterer med matematiska operatorer för RPN-operation (+-*/^)"
+"Använd tangenter med matematiska operatorer för RPN-operation (+-*/^)"
 
 #: ../data/preferences.ui.h:15
 msgid "Conversion to local currency"
@@ -2549,14 +2549,14 @@ msgstr ""
 
 #: ../data/preferences.ui.h:17
 msgid "Update exchange rates on start"
-msgstr "Updatera växelkurser vid start"
+msgstr "Uppdatera växelkurser vid start"
 
 #: ../data/preferences.ui.h:18
 msgid ""
 "If current exchange rates shall be downloaded from the internet at program "
 "start"
 msgstr ""
-"Huruvida uppdaterade växelkurser skall hämtas från intenet vid programstart"
+"Huruvida uppdaterade växelkurser skall hämtas från internet vid programstart"
 
 #: ../data/preferences.ui.h:19
 msgid "Exchange rates updates"
@@ -2624,7 +2624,7 @@ msgstr ""
 
 #: ../data/preferences.ui.h:34
 msgid "If \"e\" shall be used instead of \"E\" in numbers"
-msgstr "Om \"e\" skall anvädas istället för \"E\" i nummer"
+msgstr "Om \"e\" skall användas istället för \"E\" i nummer"
 
 #: ../data/preferences.ui.h:35
 msgid "Use E-notation instead of 10<sup><i>n</i></sup>"
@@ -2850,7 +2850,7 @@ msgid ""
 msgstr ""
 "Klassificering av enheten. Alias-enheter är definierade i relation till en "
 "annan enhet, sammansatta enheter är en sammanslagning av flera enheter. "
-"Grundenheter är inte definierade i föhållande till andra enheter."
+"Grundenheter är inte definierade i förhållande till andra enheter."
 
 #: ../data/unitedit.ui.h:17
 msgid "Base Unit"
@@ -3045,7 +3045,7 @@ msgstr "Typ"
 
 #: ../data/unknownedit.ui.h:13
 msgid "Real Number"
-msgstr "Reelt tal"
+msgstr "Reellt tal"
 
 #: ../data/unknownedit.ui.h:14
 msgid "Rational Number"
@@ -3089,7 +3089,7 @@ msgstr "Sätt in vald variabel i uttrycket"
 
 #: ../data/variables.ui.h:10
 msgid "Delete the selected variable"
-msgstr "Ta bort vald variabler"
+msgstr "Ta bort vald variabel"
 
 #: ../data/variables.ui.h:11
 msgid "(De)activate the selected variable"
@@ -3383,12 +3383,12 @@ msgstr "CPLX"
 
 #: ../src/callbacks.cc:1227
 msgid "Do you wish to update the exchange rates now?"
-msgstr "Vill du updatera växelkurserna nu?"
+msgstr "Vill du uppdatera växelkurserna nu?"
 
 #: ../src/callbacks.cc:1228
 #, c-format
 msgid "It has been %s day(s) since the exchange rates last were updated."
-msgstr "Det var %s dag(ar) sedan växelkurserna senast updaterades."
+msgstr "Det var %s dag(ar) sedan växelkurserna senast uppdaterades."
 
 #: ../src/callbacks.cc:1229
 msgid "Do not ask again"
@@ -3699,7 +3699,7 @@ msgstr "förvalda antaganden"
 #: ../src/callbacks.cc:19332 ../src/callbacks.cc:19350
 #: ../src/callbacks.cc:19383
 msgid "Variable does not exist anymore."
-msgstr "Variables existerar inte längre."
+msgstr "Variabel existerar inte längre."
 
 #: ../src/callbacks.cc:3478
 msgid "Data Retrieval Function"
@@ -3743,7 +3743,7 @@ msgstr "Duodecimalt tal"
 
 #: ../src/callbacks.cc:4521
 msgid "Complex exponential form"
-msgstr "Complex exponentiell form"
+msgstr "Komplex exponentiell form"
 
 #: ../src/callbacks.cc:4523 ../src/callbacks.cc:17238
 msgid "Factors"
@@ -4220,7 +4220,7 @@ msgstr "Omvandling to gregoriansk kalender misslyckades"
 #: ../src/callbacks.cc:18274
 #, c-format
 msgid "Calendar conversion failed for: %s."
-msgstr "Kalendermmvandling misslyckades för: ."
+msgstr "Kalenderomvandling misslyckades för: ."
 
 #: ../src/callbacks.cc:18868
 msgid "Select file to save PNG image to"
@@ -4232,7 +4232,7 @@ msgstr "Tillåtna filtyper"
 
 #: ../src/callbacks.cc:18876 ../src/callbacks.cc:21732
 msgid "All Files"
-msgstr "All filer"
+msgstr "Alla filer"
 
 #. do not delete units that are used by other units
 #: ../src/callbacks.cc:19271
@@ -4284,7 +4284,7 @@ msgstr ""
 
 #: ../src/callbacks.cc:21718
 msgid "Select file to export"
-msgstr "Välj fil att exporta till"
+msgstr "Välj fil att exportera till"
 
 #: ../src/callbacks.cc:21790 ../src/callbacks.cc:21800
 #: ../src/callbacks.cc:21809
@@ -4313,7 +4313,7 @@ msgstr "Alkalimetall"
 
 #: ../src/callbacks.cc:22119
 msgid "Alkaline-Earth Metal"
-msgstr "Jordalkalimetall"
+msgstr "Alkalisk Jordartsmetall"
 
 #: ../src/callbacks.cc:22120
 msgid "Lanthanide"


### PR DESCRIPTION
I found some small spelling mistakes when I used the program, and looked through the translation to see if I could find more. I left the English words in the Swedish translation that was there earlier (for example Archimedes instead of Arkimedes).