### PR TITLE
data: install appdata xml file in metainfo instead of appdata

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -18,7 +18,7 @@ desktopdir = $(datadir)/applications
 
 appdata_IN_FILES = qalculate-gtk.appdata.xml.in
 appdata_DATA = $(appdata_IN_FILES:.xml.in=.xml)
-appdatadir = $(datadir)/appdata
+appdatadir = $(datadir)/metainfo
 @INTLTOOL_XML_RULE@
 
 pixmapsdir = $(datadir)/pixmaps


### PR DESCRIPTION
Spec says:

 Applications can ship one or more files in /usr/share/metainfo/%{id}.appdata.xml.

 https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Application.html