### PR TITLE
Make searchprovider.o depend on gnome-search-provider2.h

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -42,7 +42,7 @@ qalculate_gtk_LDADD = \
 	@QALCULATE_LIBS@
 
 if ENABLE_SEARCH_PROVIDER
-gnome-search-provider2.h gnome-search-provider2.c: $(top_srcdir)/data/org.gnome.ShellSearchProvider2.xml
+gnome-search-provider2.c: $(top_srcdir)/data/org.gnome.ShellSearchProvider2.xml
 	$(AM_V_GEN)gdbus-codegen \
 		--c-namespace Shell \
 		--generate-c-code gnome-search-provider2 \
@@ -59,6 +59,8 @@ qalculate_search_provider_LDADD = \
 	@GLIB_LIBS@ \
 	@GTK_LIBS@ \
 	@QALCULATE_LIBS@
+
+searchprovider.o: gnome-search-provider2.c
 
 dbusservicedir = $(datadir)/dbus-1/services
 dbusservice_DATA = io.github.Qalculate.SearchProvider.service


### PR DESCRIPTION
Otherwise there are non-deterministic build failures with `make -j`.  You can reproduce this by running the following on a clean master:
```
./autogen.sh
./configure
cd src
make searchprovider.o
```
This results in `searchprovider.cc:28:10: fatal error: gnome-search-provider2.h: No such file or directory`.

(Not sure if this is idiomatic automake syntax though.)