### PR TITLE
Do not use more than three characters of calculator buttons

### DIFF
--- a/po/ru.po
+++ b/po/ru.po
@@ -1848,7 +1848,7 @@ msgstr "Отображение чисел"
 
 #: ../data/main.ui.h:249
 msgid "Pure"
-msgstr "Простая"
+msgstr "Простое"
 
 #: ../data/main.ui.h:250 ../src/callbacks.cc:7165
 msgid "Number base"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-05-02 13:30+0700\n"
-"PO-Revision-Date: 2021-05-03 21:42+0700\n"
+"PO-Revision-Date: 2021-05-06 18:14+0700\n"
 "Last-Translator: Damir Islamov <damir@secretlaboratory.ru>\n"
 "Language-Team: Russian <kde-russian@lists.kde.ru>\n"
 "Language: ru\n"
@@ -1909,7 +1909,7 @@ msgstr "Сохранить результат как переменную"
 
 #: ../data/main.ui.h:265
 msgid "STO"
-msgstr "СОХР"
+msgstr "СХР"
 
 #: ../data/main.ui.h:266
 msgid "Convert number bases"
@@ -1967,11 +1967,11 @@ msgstr "Показать/скрыть правую клавиатуру"
 
 #: ../data/main.ui.h:281 ../data/nbases.ui.h:28 ../src/interface.cc:882
 msgid "DEL"
-msgstr "УДАЛ"
+msgstr "УДЛ"
 
 #: ../data/main.ui.h:282 ../data/nbases.ui.h:30 ../src/interface.cc:881
 msgid "AC"
-msgstr "ЧИСТ"
+msgstr "ЧСТ"
 
 #: ../data/main.ui.h:283 ../src/interface.cc:883 ../src/interface.cc:3869
 msgid "Previous result"


### PR DESCRIPTION
to avoid widening of the keypad