### PR TITLE
Add Catalan translation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -142,7 +142,7 @@ AC_SUBST(GETTEXT_PACKAGE)
 AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE,"$GETTEXT_PACKAGE",[The package name for gettext])
 
 dnl Please keep this in alphabetical order
-ALL_LINGUAS="de es fr nl pt_BR ru sl sv zh_CN"
+ALL_LINGUAS="ca de es fr nl pt_BR ru sl sv zh_CN"
 AM_GNU_GETTEXT(external)
 AM_GNU_GETTEXT_VERSION([0.21])
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -1,0 +1,5563 @@
+# Catalan translations for qalculate-gtk package.
+# Copyright (C) 2021 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the qalculate-gtk package.
+# Alex Henrie <alexhenrie24@gmail.com>, 2021.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: qalculate-gtk\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-06-10 22:38-0600\n"
+"PO-Revision-Date: 2021-06-10 22:39-0600\n"
+"Last-Translator: Alex Henrie <alexhenrie24@gmail.com>\n"
+"Language-Team: Catalan <ca@dodds.net>\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.4.3\n"
+
+#: ../data/qalculate-gtk.desktop.in.h:1 ../src/callbacks.cc:10757
+#: ../src/callbacks.cc:10764 ../src/callbacks.cc:10779
+msgid "Qalculate!"
+msgstr "Qalculate!"
+
+#: ../data/qalculate-gtk.desktop.in.h:2
+msgid "Calculator"
+msgstr "Calculadora"
+
+#: ../data/qalculate-gtk.desktop.in.h:3
+#: ../data/qalculate-gtk.appdata.xml.in.h:2 ../src/callbacks.cc:31888
+msgid "Powerful and easy to use calculator"
+msgstr "Calculadora poderosa i fàcil a usar"
+
+#: ../data/qalculate-gtk.desktop.in.h:4
+msgid "calculation;arithmetic;scientific;financial;"
+msgstr "calculation;arithmetic;scientific;financial;"
+
+#: ../data/qalculate-gtk.appdata.xml.in.h:1
+msgid "Qalculate! (GTK UI)"
+msgstr "Qalculate! (GTK UI)"
+
+#: ../data/qalculate-gtk.appdata.xml.in.h:3
+msgid ""
+"Qalculate! is a multi-purpose cross-platform desktop calculator. It is "
+"simple to use but provides power and versatility normally reserved for "
+"complicated math packages, as well as useful tools for everyday needs (such "
+"as currency conversion and percent calculation)."
+msgstr ""
+"El Qalculate! és una calculadora d'escriptori per a diverses plataformes i "
+"finalitats. És senzill a usar però proporciona poder i versatilitat que "
+"normalment es reserva als paquets de matemàtica complicats, així com eines "
+"útils per a necessitats diàries (com la conversió de monedes i calculació de "
+"percentatge)."
+
+#: ../data/qalculate-gtk.appdata.xml.in.h:4
+msgid ""
+"Features include a large library of customizable functions, unit "
+"calculations and conversion, physical constants, symbolic calculations "
+"(including integrals and equations), arbitrary precision, uncertainty "
+"propagation, interval arithmetic, plotting, and a user-friendly interface."
+msgstr ""
+"Les característiques inclouen una biblioteca amplia de funcions "
+"personalitzables, calculació i conversió d'unitat, constants físics, càlculs "
+"simbòlics (incloent integrals i equacions), precisió arbitrària, propagació "
+"d'incertesa, aritmètica d'interval, dibuix i una interfície fàcil d'emprar."
+
+#: ../data/argumentrules.ui.h:1
+msgid "Argument Rules"
+msgstr "Regles d'argument"
+
+#: ../data/argumentrules.ui.h:2 ../data/buttonsedit.ui.h:9
+#: ../data/csvexport.ui.h:2 ../data/csvimport.ui.h:2 ../data/datasetedit.ui.h:2
+#: ../data/datasets.ui.h:2 ../data/functionedit.ui.h:3 ../data/matrix.ui.h:2
+#: ../data/matrixedit.ui.h:3 ../data/shortcuts.ui.h:7
+#: ../data/simplefunctionedit.ui.h:3 ../data/unitedit.ui.h:3
+#: ../data/unknownedit.ui.h:3 ../data/variableedit.ui.h:3
+#: ../src/callbacks.cc:2439 ../src/callbacks.cc:16697 ../src/callbacks.cc:17683
+#: ../src/callbacks.cc:17802 ../src/callbacks.cc:18933
+#: ../src/callbacks.cc:18989 ../src/callbacks.cc:26089
+#: ../src/callbacks.cc:26567 ../src/callbacks.cc:27801
+#: ../src/callbacks.cc:29511 ../src/callbacks.cc:33131
+#: ../src/callbacks.cc:33157 ../src/callbacks.cc:33175
+#: ../src/callbacks.cc:33219 ../src/callbacks.cc:34404
+#: ../src/callbacks.cc:34930
+msgid "_Cancel"
+msgstr "_Cancel·la"
+
+#: ../data/argumentrules.ui.h:3
+msgid "Do not save modifications"
+msgstr "No desis modificacions"
+
+#: ../data/argumentrules.ui.h:4 ../data/buttonsedit.ui.h:10
+#: ../data/csvexport.ui.h:3 ../data/csvimport.ui.h:4 ../data/datasetedit.ui.h:4
+#: ../data/datasets.ui.h:4 ../data/functionedit.ui.h:5
+#: ../data/matrixedit.ui.h:5 ../data/shortcuts.ui.h:8
+#: ../data/simplefunctionedit.ui.h:5 ../data/unitedit.ui.h:5
+#: ../data/unknownedit.ui.h:5 ../data/variableedit.ui.h:5
+#: ../src/callbacks.cc:2439 ../src/callbacks.cc:2685 ../src/callbacks.cc:2774
+#: ../src/callbacks.cc:17683 ../src/callbacks.cc:17802
+#: ../src/callbacks.cc:26089 ../src/callbacks.cc:26567
+#: ../src/callbacks.cc:33175 ../src/callbacks.cc:34930
+msgid "_OK"
+msgstr "_D'acord"
+
+#: ../data/argumentrules.ui.h:5
+msgid "Accept the modification of argument rules"
+msgstr "Accepta la modificació de regles d'argument"
+
+#: ../data/argumentrules.ui.h:6
+msgid "Enable rules and type test"
+msgstr "Habilita regles i verificació de tipus"
+
+#: ../data/argumentrules.ui.h:7
+msgid "Custom condition"
+msgstr "Condició personalitzada"
+
+#: ../data/argumentrules.ui.h:8
+msgid ""
+"For example if argument is a matrix that must have equal number of rows and "
+"columns: rows(\\x) = columns(\\x)"
+msgstr ""
+"Per exemple, si l'argument és una matriu que ha de tenir un nombre igual de "
+"files i columnes: rows(\\x) = columns(\\x)"
+
+#: ../data/argumentrules.ui.h:9
+msgid "Allow matrix"
+msgstr "Permet matriu"
+
+#: ../data/argumentrules.ui.h:10
+msgid "Forbid zero"
+msgstr "Prohibeix zero"
+
+#: ../data/argumentrules.ui.h:11
+msgid "Handle vector"
+msgstr "Tractar amb vectors"
+
+#: ../data/argumentrules.ui.h:12
+msgid "Calculate function for each separate element in vector."
+msgstr "Calcula la funció per cada element distint en el vector."
+
+#: ../data/argumentrules.ui.h:13
+msgid "Min"
+msgstr "Mín"
+
+#: ../data/argumentrules.ui.h:14
+msgid "Include equals"
+msgstr "Inclusiu"
+
+#: ../data/argumentrules.ui.h:15
+msgid "Max"
+msgstr "Màx"
+
+#: ../data/buttonsedit.ui.h:1 ../data/main.ui.h:64 ../data/shortcuts.ui.h:1
+msgid "Keyboard Shortcuts"
+msgstr "Dreceres de teclat"
+
+#: ../data/buttonsedit.ui.h:2 ../data/calendarconversion.ui.h:2
+#: ../data/datasets.ui.h:7 ../data/decimals.ui.h:2 ../data/floatingpoint.ui.h:2
+#: ../data/functionedit.ui.h:57 ../data/functions.ui.h:2
+#: ../data/namesedit.ui.h:2 ../data/nbases.ui.h:2 ../data/percentage.ui.h:5
+#: ../data/plot.ui.h:5 ../data/precision.ui.h:2 ../data/preferences.ui.h:2
+#: ../data/setbase.ui.h:2 ../data/shortcuts.ui.h:2 ../data/units.ui.h:2
+#: ../data/variables.ui.h:2 ../src/callbacks.cc:2441 ../src/callbacks.cc:14668
+#: ../src/callbacks.cc:16689 ../src/callbacks.cc:26014
+#: ../src/callbacks.cc:34772
+msgid "_Close"
+msgstr "_Tanca"
+
+#: ../data/buttonsedit.ui.h:3 ../src/interface.cc:4049
+msgid "Label"
+msgstr "Etiqueta"
+
+#: ../data/buttonsedit.ui.h:4 ../src/interface.cc:4052
+msgid "Left-click"
+msgstr "Clic esquerre"
+
+#: ../data/buttonsedit.ui.h:5 ../src/interface.cc:4055
+msgid "Right-click"
+msgstr "Clic dret"
+
+#: ../data/buttonsedit.ui.h:6 ../src/interface.cc:4058
+msgid "Middle-click"
+msgstr "Clic del mig"
+
+#: ../data/buttonsedit.ui.h:7
+msgid "Reset"
+msgstr "Restableix"
+
+#: ../data/buttonsedit.ui.h:8
+msgid "Button Action"
+msgstr "Acció del botó"
+
+#: ../data/buttonsedit.ui.h:11 ../data/shortcuts.ui.h:9
+#: ../data/variableedit.ui.h:9 ../src/interface.cc:2130
+#: ../src/interface.cc:2370 ../src/interface.cc:3898 ../src/callbacks.cc:14726
+msgid "Value"
+msgstr "Valor"
+
+#: ../data/buttonsedit.ui.h:12 ../data/functionedit.ui.h:25
+#: ../data/shortcuts.ui.h:10
+msgid "Argument name"
+msgstr "Nom d'argument"
+
+#: ../data/calendarconversion.ui.h:1 ../data/main.ui.h:40
+msgid "Calendar Conversion"
+msgstr "Conversió de calendari"
+
+#: ../data/csvexport.ui.h:1
+msgid "Export CSV File"
+msgstr "Exporta fitxer CSV"
+
+#: ../data/csvexport.ui.h:4
+msgid "Current result"
+msgstr "Resultat actual"
+
+#: ../data/csvexport.ui.h:5
+msgid "Matrix/vector variable"
+msgstr "Variable de matriu/vector"
+
+#: ../data/csvexport.ui.h:6 ../data/csvimport.ui.h:6
+#: ../data/functionedit.ui.h:45
+msgid "File"
+msgstr "Fitxer"
+
+#: ../data/csvexport.ui.h:7 ../data/csvimport.ui.h:23
+msgid "Delimiter"
+msgstr "Delimitador"
+
+#: ../data/csvexport.ui.h:8 ../data/csvimport.ui.h:25
+msgid "Comma"
+msgstr "Coma"
+
+#: ../data/csvexport.ui.h:9 ../data/csvimport.ui.h:26
+msgid "Tabulator"
+msgstr "Tabulador"
+
+#: ../data/csvexport.ui.h:10 ../data/csvimport.ui.h:27
+msgid "Semicolon"
+msgstr "Punt i coma"
+
+#: ../data/csvexport.ui.h:11 ../data/csvimport.ui.h:28
+msgid "Space"
+msgstr "Espai"
+
+#: ../data/csvexport.ui.h:12 ../data/csvimport.ui.h:29
+msgid "Other"
+msgstr "Altre"
+
+#: ../data/csvimport.ui.h:1
+msgid "Import CSV File"
+msgstr "Importació de fitxer CSV"
+
+#: ../data/csvimport.ui.h:3
+msgid "Do not import the file"
+msgstr "No importis el fitxer"
+
+#: ../data/csvimport.ui.h:5
+msgid "Import the file"
+msgstr "Importa el fitxer"
+
+#: ../data/csvimport.ui.h:7
+msgid "Name of the data file to import"
+msgstr "Nom del fitxer de dades a importar"
+
+#: ../data/csvimport.ui.h:8
+msgid "Select a file"
+msgstr "Selecciona un fitxer"
+
+#: ../data/csvimport.ui.h:9
+msgid "Import as"
+msgstr "Importa com a"
+
+#: ../data/csvimport.ui.h:10 ../data/functionedit.ui.h:33 ../data/main.ui.h:21
+#: ../data/matrix.ui.h:1 ../data/matrixedit.ui.h:18 ../src/callbacks.cc:16702
+msgid "Matrix"
+msgstr "Matriu"
+
+#: ../data/csvimport.ui.h:11
+msgid "If a matrix shall be generated from the contents of the file"
+msgstr "Si es generarà una matriu dels continguts del fitxer"
+
+#: ../data/csvimport.ui.h:12 ../src/callbacks.cc:17573
+#: ../src/callbacks.cc:27710
+msgid "Vectors"
+msgstr "Vectors"
+
+#: ../data/csvimport.ui.h:13
+msgid "If vectors shall be generated from the contents of the file"
+msgstr "Si es generaran vectors dels continguts del fitxer"
+
+#: ../data/csvimport.ui.h:14 ../data/datasetedit.ui.h:6
+#: ../data/functionedit.ui.h:7 ../data/matrixedit.ui.h:8
+#: ../data/namesedit.ui.h:3 ../data/simplefunctionedit.ui.h:6
+#: ../data/unitedit.ui.h:7 ../data/unknownedit.ui.h:7
+#: ../data/variableedit.ui.h:6 ../src/interface.cc:2221
+#: ../src/interface.cc:2439 ../src/interface.cc:2838 ../src/interface.cc:3101
+#: ../src/interface.cc:3140 ../src/callbacks.cc:18940 ../src/callbacks.cc:26096
+msgid "Name"
+msgstr "Nom"
+
+#: ../data/csvimport.ui.h:15
+msgid ""
+"Name (or name prefix) used to reference generated variable(s) in expressions"
+msgstr ""
+"Nom (o prefix de nom) usat per a referir a les variables generades en "
+"expressions"
+
+#: ../data/csvimport.ui.h:16 ../data/datasetedit.ui.h:9
+#: ../data/functionedit.ui.h:11 ../data/matrixedit.ui.h:12
+#: ../data/unitedit.ui.h:11 ../data/unknownedit.ui.h:26
+#: ../data/variableedit.ui.h:16
+msgid "Descriptive name"
+msgstr "Nom descriptiu"
+
+#: ../data/csvimport.ui.h:17 ../data/matrixedit.ui.h:13
+#: ../data/unknownedit.ui.h:27 ../data/variableedit.ui.h:15
+msgid "Title displayed in menus and in variable manager"
+msgstr "Títol mostrat en els menús i en el gestor de variables"
+
+#: ../data/csvimport.ui.h:18 ../data/functionedit.ui.h:10 ../data/main.ui.h:237
+#: ../data/matrixedit.ui.h:11 ../data/unitedit.ui.h:10
+#: ../data/unknownedit.ui.h:24 ../data/variableedit.ui.h:14
+#: ../src/interface.cc:2232 ../src/interface.cc:2323 ../src/interface.cc:2386
+#: ../src/interface.cc:2463
+msgid "Category"
+msgstr "Categoria"
+
+#: ../data/csvimport.ui.h:19
+msgid "First row"
+msgstr "Primera fila"
+
+#: ../data/csvimport.ui.h:20
+msgid "The first row with data to import in the file"
+msgstr "La primera fila amb dades a importar en el fitxer"
+
+#: ../data/csvimport.ui.h:21
+msgid "Includes headings"
+msgstr "Inclou encapçalaments"
+
+#: ../data/csvimport.ui.h:22
+msgid "If the first row contains column headings"
+msgstr "Si la primera fila conté encapçalaments de columna"
+
+#: ../data/csvimport.ui.h:24
+msgid "Delimiter used to separate columns in the file"
+msgstr "Delimitador usat per a separar les columnes en el fitxer"
+
+#: ../data/csvimport.ui.h:30
+msgid "Custom delimiter"
+msgstr "Delimitador personalitzat"
+
+#: ../data/datasetedit.ui.h:1
+msgid "Edit Data Property"
+msgstr "Edició de propietat de dades"
+
+#: ../data/datasetedit.ui.h:3
+msgid "Do not create/modify this data set"
+msgstr "No creis o no modifiques aquest conjunt de dades"
+
+#: ../data/datasetedit.ui.h:5
+msgid "Accept the creation/modification of this data set"
+msgstr "Accepta la creació o modificació d'aquest conjunt de dades"
+
+#: ../data/datasetedit.ui.h:7
+msgid "Name used for reference"
+msgstr "Nom usat per a referència"
+
+#: ../data/datasetedit.ui.h:8 ../data/functionedit.ui.h:9
+#: ../data/matrixedit.ui.h:10 ../data/unitedit.ui.h:9
+#: ../data/unknownedit.ui.h:9 ../data/variableedit.ui.h:8
+#: ../src/callbacks.cc:4645 ../src/callbacks.cc:5695
+msgid "Properties"
+msgstr "Propietats"
+
+#: ../data/datasetedit.ui.h:10
+msgid "Title displayed in menus and in data set manager"
+msgstr "Títol mostrat en els menús i en el gestor de conjunts de dades"
+
+#: ../data/datasetedit.ui.h:11 ../data/functionedit.ui.h:15
+#: ../data/unitedit.ui.h:18
+msgid "Description"
+msgstr "Descripció"
+
+#: ../data/datasetedit.ui.h:12
+msgid "Description of this data property"
+msgstr "Descripció d'aquesta propietat de dades"
+
+#: ../data/datasetedit.ui.h:13
+msgid "Value Type"
+msgstr "Tipus de valor"
+
+#: ../data/datasetedit.ui.h:14 ../data/functionedit.ui.h:30
+#: ../src/callbacks.cc:26020
+msgid "Text"
+msgstr "Text"
+
+#: ../data/datasetedit.ui.h:15 ../data/functionedit.ui.h:27 ../data/main.ui.h:7
+#: ../data/unknownedit.ui.h:12
+msgid "Number"
+msgstr "Nombre"
+
+#: ../data/datasetedit.ui.h:16 ../data/functionedit.ui.h:18 ../data/plot.ui.h:8
+#: ../data/simplefunctionedit.ui.h:8 ../src/interface.cc:2866
+#: ../src/interface.cc:3765
+msgid "Expression"
+msgstr "Expressió"
+
+#: ../data/datasetedit.ui.h:17
+msgid "Hide"
+msgstr "Amaga"
+
+#: ../data/datasetedit.ui.h:18
+msgid "Use as key"
+msgstr "Usa com a clau"
+
+#: ../data/datasetedit.ui.h:19
+msgid "Approximate value"
+msgstr "Valor aproximat"
+
+#: ../data/datasetedit.ui.h:20
+msgid "Case sensitive value"
+msgstr "Valor sensitiu a majúscules i minúscules"
+
+#: ../data/datasetedit.ui.h:21
+msgid "Value uses brackets"
+msgstr "El valor usa claudàtors"
+
+#: ../data/datasetedit.ui.h:22 ../data/main.ui.h:235
+msgid "Unit expression"
+msgstr "Expressió d'unitat"
+
+#: ../data/datasetedit.ui.h:23 ../src/callbacks.cc:17122
+msgid "Edit Data Set"
+msgstr "Edició de conjunt de dades"
+
+#: ../data/datasetedit.ui.h:24 ../data/plot.ui.h:7 ../src/interface.cc:3098
+#: ../src/interface.cc:3762
+msgid "Title"
+msgstr "Títol"
+
+#: ../data/datasetedit.ui.h:25
+msgid "Data file"
+msgstr "Fitxer de dades"
+
+#: ../data/datasetedit.ui.h:26
+msgid "Description of this data set"
+msgstr "Descripció d'aquest conjunt de dades"
+
+#: ../data/datasetedit.ui.h:27
+msgid "Copyright"
+msgstr "Dret d'autor"
+
+#: ../data/datasetedit.ui.h:28 ../data/functionedit.ui.h:17
+#: ../data/unitedit.ui.h:20
+msgid "General"
+msgstr "General"
+
+#: ../data/datasetedit.ui.h:29
+msgid "Properties:"
+msgstr "Propietats:"
+
+#: ../data/datasetedit.ui.h:30
+msgid "Definition of the properties of this data set"
+msgstr "Definició de les propietats d'aquest conjunt de dades"
+
+#: ../data/datasetedit.ui.h:31 ../data/functions.ui.h:3 ../data/main.ui.h:19
+#: ../data/units.ui.h:3 ../data/variables.ui.h:3
+msgid "_New"
+msgstr "_Nou"
+
+#: ../data/datasetedit.ui.h:32 ../data/functions.ui.h:5 ../data/main.ui.h:45
+#: ../data/shortcuts.ui.h:4 ../data/units.ui.h:5 ../data/variables.ui.h:5
+msgid "_Edit"
+msgstr "_Edita"
+
+#: ../data/datasetedit.ui.h:33 ../data/functionedit.ui.h:53
+#: ../data/functions.ui.h:9 ../data/units.ui.h:11 ../data/variables.ui.h:9
+#: ../src/callbacks.cc:18989
+msgid "_Delete"
+msgstr "_Suprimeix"
+
+#: ../data/datasetedit.ui.h:34
+msgid "Name used to invoke the function in expressions"
+msgstr "Nom usat per a invocar la funció en les expressions"
+
+#: ../data/datasetedit.ui.h:35
+msgid "Object argument name"
+msgstr "Nom d'argument d'objecte"
+
+#: ../data/datasetedit.ui.h:36
+msgid "Property argument name"
+msgstr "Nom d'argument de propietat"
+
+#: ../data/datasetedit.ui.h:37
+msgid "Default property"
+msgstr "Propietat predeterminat"
+
+#: ../data/datasetedit.ui.h:38 ../data/functionedit.ui.h:42
+#: ../data/main.ui.h:24 ../data/plot.ui.h:9 ../src/interface.cc:2309
+msgid "Function"
+msgstr "Funció"
+
+#: ../data/datasets.ui.h:1 ../src/callbacks.cc:16847
+msgid "Edit Data Object"
+msgstr "Edició d'objecte de dades"
+
+#: ../data/datasets.ui.h:3
+msgid "Do not create/modify this data object"
+msgstr "No creis o no modifiques aquest objecte de dades"
+
+#: ../data/datasets.ui.h:5
+msgid "Accept the creation/modification of this data object"
+msgstr "Accepta la creació o modificació d'aquest object de dades"
+
+#. new dataset
+#: ../data/datasets.ui.h:6 ../src/callbacks.cc:17219
+msgid "Data Sets"
+msgstr "Conjunts de dades"
+
+#: ../data/datasets.ui.h:8 ../data/main.ui.h:26 ../src/interface.cc:2555
+msgid "Data Set"
+msgstr "Conjunt de dades"
+
+#: ../data/datasets.ui.h:9
+msgid "Create a new data set"
+msgstr "Crea un conjunt de dades nou"
+
+#: ../data/datasets.ui.h:10
+msgid "Edit the selected data set"
+msgstr "Edita el conjunt de dades seleccionat"
+
+#: ../data/datasets.ui.h:11
+msgid "Delete the selected data set"
+msgstr "Suprimeix el conjunt de dades seleccionat"
+
+#: ../data/datasets.ui.h:12
+msgid "Objects"
+msgstr "Objectes"
+
+#: ../data/datasets.ui.h:13
+msgid "Create a new data object"
+msgstr "Crea un objecte de dades nou"
+
+#: ../data/datasets.ui.h:14
+msgid "Edit the selected data object"
+msgstr "Edita l'objecte de dades seleccionat"
+
+#: ../data/datasets.ui.h:15
+msgid "Remove the selected data object"
+msgstr "Elimina l'object de dades seleccionat"
+
+#: ../data/datasets.ui.h:16
+msgid "Data Set Description"
+msgstr "Descripció de conjunt de dades"
+
+#: ../data/datasets.ui.h:17
+msgid "Object Attributes"
+msgstr "Atributs d'objecte"
+
+#: ../data/decimals.ui.h:1
+msgid "Decimals"
+msgstr "Decimals"
+
+#: ../data/decimals.ui.h:3 ../data/matrix.ui.h:3 ../data/plot.ui.h:6
+#: ../data/precision.ui.h:3
+msgid "Close this window"
+msgstr "Tanca aquesta finestra"
+
+#: ../data/decimals.ui.h:4
+msgid "Min decimals"
+msgstr "Mín de decimals"
+
+#: ../data/decimals.ui.h:5
+msgid "Max decimals"
+msgstr "Màx de decimals"
+
+#: ../data/decimals.ui.h:6
+msgid "Minimal number of displayed decimals"
+msgstr "Nombre mínim de decimals mostrats"
+
+#: ../data/decimals.ui.h:7
+msgid "Maximal number of decimals to display (and round to)"
+msgstr "Nombre màxim de decimals a mostrar (i al qual arrodonir)"
+
+#: ../data/floatingpoint.ui.h:1
+msgid "Floating Point Conversion"
+msgstr "Conversió de punt flotant"
+
+#: ../data/floatingpoint.ui.h:3 ../data/nbases.ui.h:7
+msgid "Decimal value"
+msgstr "Valor decimal"
+
+#: ../data/floatingpoint.ui.h:4 ../data/nbases.ui.h:6
+msgid "Binary value"
+msgstr "Valor binari"
+
+#: ../data/floatingpoint.ui.h:5 ../data/nbases.ui.h:8
+msgid "Octal value"
+msgstr "Valor octal"
+
+#: ../data/floatingpoint.ui.h:6
+msgid "Hexadecimal representation"
+msgstr "Representació hexadecimal"
+
+#: ../data/floatingpoint.ui.h:7
+msgid "Conversion error"
+msgstr "Error de conversió"
+
+#: ../data/floatingpoint.ui.h:8
+msgid "Binary representation"
+msgstr "Representació binària"
+
+#: ../data/floatingpoint.ui.h:9
+msgid "Floating point value"
+msgstr "Valor de punt flotant"
+
+#: ../data/floatingpoint.ui.h:10
+msgid "Format"
+msgstr "Format"
+
+#: ../data/floatingpoint.ui.h:11
+msgid "16-bit (half precision)"
+msgstr "16 bits (precisió mitja)"
+
+#: ../data/floatingpoint.ui.h:12
+msgid "32-bit (single precision)"
+msgstr "32 bits (precisió singular)"
+
+#: ../data/floatingpoint.ui.h:13
+msgid "64-bit (double precision)"
+msgstr "64 bits (precisió doble)"
+
+#: ../data/floatingpoint.ui.h:14
+msgid "80-bit (x86 extended format)"
+msgstr "80 bits (format x86 estès)"
+
+#: ../data/floatingpoint.ui.h:15
+msgid "128-bit (quadruple precision)"
+msgstr "128 bits (precisió quàdruple)"
+
+#: ../data/floatingpoint.ui.h:16 ../data/nbases.ui.h:12
+msgid "Hexadecimal value"
+msgstr "Valor hexadecimal"
+
+#: ../data/functionedit.ui.h:1 ../src/callbacks.cc:15662
+#: ../src/callbacks.cc:15867
+msgid "Edit Function"
+msgstr "Edició de funció"
+
+#: ../data/functionedit.ui.h:2 ../data/main.ui.h:196 ../data/matrixedit.ui.h:2
+#: ../data/plot.ui.h:2 ../data/unitedit.ui.h:2 ../data/unknownedit.ui.h:2
+#: ../data/variableedit.ui.h:2
+msgid "_Help"
+msgstr "A_juda"
+
+#: ../data/functionedit.ui.h:4
+msgid "Do not create/modify this function"
+msgstr "No creis ni modifiques aquesta funció"
+
+#: ../data/functionedit.ui.h:6
+msgid "Accept the creation/modification of this function"
+msgstr "Accepta la creació o modificació d'aquesta funció"
+
+#: ../data/functionedit.ui.h:8
+msgid "Name used to invoke this function in expressions"
+msgstr "Nom usat per a invocar aquesta funció en les expressions"
+
+#: ../data/functionedit.ui.h:12
+msgid "Title displayed in menus and in function manager"
+msgstr "Títol que es mostra en els menús i en el gestor de funcions"
+
+#: ../data/functionedit.ui.h:13
+msgid "Hide function"
+msgstr "Amaga la funció"
+
+#: ../data/functionedit.ui.h:14
+msgid "If this function shall be hidden in menus"
+msgstr "Si aquesta funció es deu amagar en els menús"
+
+#: ../data/functionedit.ui.h:16 ../data/unitedit.ui.h:19
+msgid "Description of this function"
+msgstr "Descripció d'aquesta funció"
+
+#: ../data/functionedit.ui.h:19
+msgid ""
+"Use \\x for the first, \\y for the second and \\z for the third argument. "
+"For more information click the help button."
+msgstr ""
+"Useu \\x pel primer, \\y pel segon i \\z pel tercer argument. Per més "
+"informació, feu clic en el botó d'ajuda."
+
+#: ../data/functionedit.ui.h:20
+msgid "Condition"
+msgstr "Condició"
+
+#: ../data/functionedit.ui.h:21
+msgid ""
+"Condition that must be true for the function (e.g. if the second argument "
+"must be greater than the first: \"\\y > \\x\")"
+msgstr ""
+"La condició que ha de ser cert per a la funció (per exemple, si el segon "
+"argument ha de ser més gran que el primer: \"\\y > \\x\")"
+
+#: ../data/functionedit.ui.h:22
+msgid "Sub-Functions"
+msgstr "Subfuncions"
+
+#: ../data/functionedit.ui.h:23
+msgid "Arguments:"
+msgstr "Arguments:"
+
+#: ../data/functionedit.ui.h:24
+msgid "Definition of this function's arguments"
+msgstr "Definició dels arguments d'aquesta funció"
+
+#: ../data/functionedit.ui.h:26
+msgid "Free"
+msgstr "Libre"
+
+#: ../data/functionedit.ui.h:28 ../data/main.ui.h:11
+#: ../data/unknownedit.ui.h:15
+msgid "Integer"
+msgstr "Enter"
+
+#: ../data/functionedit.ui.h:29
+msgid "Symbol"
+msgstr "Símbol"
+
+#: ../data/functionedit.ui.h:31
+msgid "Date"
+msgstr "Dada"
+
+#: ../data/functionedit.ui.h:32 ../data/main.ui.h:22 ../data/matrix.ui.h:11
+#: ../data/matrixedit.ui.h:20 ../src/callbacks.cc:16700
+msgid "Vector"
+msgstr "Vector"
+
+#: ../data/functionedit.ui.h:34
+msgid "Positive number"
+msgstr "Nombre positiu"
+
+#: ../data/functionedit.ui.h:35
+msgid "Non-zero number"
+msgstr "Nombre no zero"
+
+#: ../data/functionedit.ui.h:36
+msgid "Non-negative number"
+msgstr "Nombre no negatiu"
+
+#: ../data/functionedit.ui.h:37
+msgid "Positive integer"
+msgstr "Enter positiu"
+
+#: ../data/functionedit.ui.h:38
+msgid "Non-zero integer"
+msgstr "Enter no zero"
+
+#: ../data/functionedit.ui.h:39
+msgid "Non-negative integer"
+msgstr "Enter no negatiu"
+
+#: ../data/functionedit.ui.h:40 ../data/main.ui.h:12
+#: ../data/unknownedit.ui.h:16
+msgid "Boolean"
+msgstr "Booleà"
+
+#: ../data/functionedit.ui.h:41 ../src/callbacks.cc:17227
+msgid "Object"
+msgstr "Objecte"
+
+#: ../data/functionedit.ui.h:43 ../data/main.ui.h:27 ../src/interface.cc:2443
+#: ../src/interface.cc:2447
+msgid "Unit"
+msgstr "Unitat"
+
+#: ../data/functionedit.ui.h:44 ../data/main.ui.h:20 ../src/interface.cc:2366
+msgid "Variable"
+msgstr "Variable"
+
+#: ../data/functionedit.ui.h:46
+msgid "Angle"
+msgstr "Angle"
+
+#: ../data/functionedit.ui.h:47 ../src/callbacks.cc:23593
+msgid "Data object"
+msgstr "Objecte de dades"
+
+#: ../data/functionedit.ui.h:48
+msgid "Data property"
+msgstr "Propietat d'objecte"
+
+#: ../data/functionedit.ui.h:49 ../data/plot.ui.h:34 ../data/shortcuts.ui.h:3
+msgid "_Add"
+msgstr "_Afegeix"
+
+#: ../data/functionedit.ui.h:50
+msgid "Add entered argument definition"
+msgstr "Afegeix la definició d'argument introduïda"
+
+#: ../data/functionedit.ui.h:51 ../data/functions.ui.h:13 ../data/plot.ui.h:35
+#: ../src/callbacks.cc:34930
+msgid "_Apply"
+msgstr "_Aplica"
+
+#: ../data/functionedit.ui.h:52
+msgid "Modify selected argument"
+msgstr "Modifica l'argument seleccionat"
+
+#: ../data/functionedit.ui.h:54
+msgid "Remove selected argument"
+msgstr "Elimina l'argument seleccionat"
+
+#: ../data/functionedit.ui.h:55
+msgid "Rules"
+msgstr "Regles"
+
+#: ../data/functionedit.ui.h:56
+msgid "Edit conditions for selected argument"
+msgstr "Edita les condicions per a l'argument seleccionat"
+
+#: ../data/functionedit.ui.h:58
+msgid "Close this dialog"
+msgstr "Tanca aquest diàleg"
+
+#: ../data/functionedit.ui.h:59 ../src/interface.cc:2870
+msgid "Precalculate"
+msgstr "Precalcula"
+
+#: ../data/functionedit.ui.h:60
+msgid "Calculate the subfunction only once, before the parent function"
+msgstr "Calcula la subfunció només una vegada, abans de la funció mare"
+
+#: ../data/functionedit.ui.h:61
+msgid "Add entered subfunction"
+msgstr "Afegeix la subfunció introduïda"
+
+#: ../data/functionedit.ui.h:62
+msgid "Apply changes to the selected subfunction"
+msgstr "Aplica els canvis a la subfunció seleccionada"
+
+#: ../data/functionedit.ui.h:63
+msgid "Remove the selected subfunction"
+msgstr "Elimina la subfunció seleccionada"
+
+#: ../data/functions.ui.h:1 ../data/main.ui.h:143
+msgid "Functions"
+msgstr "Funcions"
+
+#: ../data/functions.ui.h:4 ../data/main.ui.h:263
+msgid "Create a new function"
+msgstr "Crea una funció nova"
+
+#: ../data/functions.ui.h:6
+msgid "Edit the selected function"
+msgstr "Edita la funció seleccionada"
+
+#: ../data/functions.ui.h:7 ../data/matrix.ui.h:4 ../data/units.ui.h:7
+#: ../data/variables.ui.h:7 ../src/callbacks.cc:14675
+msgid "_Insert"
+msgstr "_Insereix"
+
+#: ../data/functions.ui.h:8
+msgid "Insert (or execute) the selected function into the expression entry"
+msgstr "Insereix (o executa) la funció seleccionada en l'entrada d'expressió"
+
+#: ../data/functions.ui.h:10
+msgid "Delete the selected function"
+msgstr "Elimina la funció seleccionada"
+
+#: ../data/functions.ui.h:11
+msgid "(De)activate the selected function"
+msgstr "(Des)activa la funció seleccionada"
+
+#: ../data/functions.ui.h:12 ../data/units.ui.h:14 ../data/variables.ui.h:12
+#: ../src/callbacks.cc:4683 ../src/callbacks.cc:4944 ../src/callbacks.cc:5194
+msgid "Deacti_vate"
+msgstr "Desacti_va"
+
+#: ../data/functions.ui.h:14
+msgid "Apply the selected function to the current expression"
+msgstr "Aplica la funció seleccionada a l'expressió actual"
+
+#: ../data/functions.ui.h:15 ../data/units.ui.h:15 ../data/variables.ui.h:14
+msgid "Categor_y"
+msgstr "Categor_ia"
+
+#: ../data/functions.ui.h:16
+msgid "_Function"
+msgstr "_Funció"
+
+#: ../data/functions.ui.h:17
+msgid "Descri_ption"
+msgstr "Descri_pció"
+
+#: ../data/main.ui.h:1
+msgid "Degrees"
+msgstr "Graus"
+
+#: ../data/main.ui.h:2
+msgid "Radians"
+msgstr "Radians"
+
+#: ../data/main.ui.h:3
+msgid "Gradians"
+msgstr "Gradians"
+
+#: ../data/main.ui.h:4
+msgid "Default assumptions"
+msgstr "Suposicions predeterminades"
+
+#: ../data/main.ui.h:5 ../data/unknownedit.ui.h:18 ../src/callbacks.cc:34829
+msgid "Unknown"
+msgstr "Desconeguda"
+
+#: ../data/main.ui.h:6
+msgid "Not Matrix"
+msgstr "No matriu"
+
+#: ../data/main.ui.h:8
+msgid "Complex"
+msgstr "Complex"
+
+#: ../data/main.ui.h:9
+msgid "Real"
+msgstr "Real"
+
+#: ../data/main.ui.h:10
+msgid "Rational"
+msgstr "Racional"
+
+#: ../data/main.ui.h:13 ../data/unknownedit.ui.h:23
+msgid "Non-Zero"
+msgstr "No zero"
+
+#: ../data/main.ui.h:14 ../data/unknownedit.ui.h:19
+msgid "Positive"
+msgstr "Positiu"
+
+#: ../data/main.ui.h:15 ../data/unknownedit.ui.h:20
+msgid "Non-Negative"
+msgstr "No negatiu"
+
+#: ../data/main.ui.h:16 ../data/unknownedit.ui.h:21
+msgid "Negative"
+msgstr "Negatiu"
+
+#: ../data/main.ui.h:17 ../data/unknownedit.ui.h:22
+msgid "Non-Positive"
+msgstr "No positiu"
+
+#: ../data/main.ui.h:18
+msgid "_File"
+msgstr "_Fitxer"
+
+#: ../data/main.ui.h:23
+msgid "Unknown Variable"
+msgstr "Variable desconeguda"
+
+#: ../data/main.ui.h:25
+msgid "Function (simplified)"
+msgstr "Funció (simplificada)"
+
+#: ../data/main.ui.h:28
+msgid "Import CSV File…"
+msgstr "Importa un fitxer CSV…"
+
+#: ../data/main.ui.h:29
+msgid "Export CSV File…"
+msgstr "Exporta un fitxer CSV…"
+
+#: ../data/main.ui.h:30
+msgid "_Store Result…"
+msgstr "_Desa el resultat…"
+
+#: ../data/main.ui.h:31
+msgid "Save Result Image…"
+msgstr "Desa una imatge del resultat…"
+
+#: ../data/main.ui.h:32
+msgid "Save local functions, variables and units"
+msgstr "Desa les funcions, variables i unitats locals"
+
+#: ../data/main.ui.h:33
+msgid "Save Definitions"
+msgstr "Desa les definicions"
+
+#: ../data/main.ui.h:34
+msgid "Import Definitions File…"
+msgstr "Importa un fitxer de definicions…"
+
+#: ../data/main.ui.h:35
+msgid "Fetch current exchange rates from the Internet"
+msgstr "Obté taxes d'intercanvi actuals de l'Internet"
+
+#: ../data/main.ui.h:36
+msgid "Update Exchange Rates"
+msgstr "Actualitza les taxes d'intercanvi"
+
+#: ../data/main.ui.h:37
+msgid "Plot Functions/Data"
+msgstr "Dibuixa funcions/dades"
+
+#: ../data/main.ui.h:38
+msgid "Convert Number Bases"
+msgstr "Converteix bases numèriques"
+
+#: ../data/main.ui.h:39
+msgid "Floating Point Conversion (IEEE 754)"
+msgstr "Conversió de punt flotant (IEEE 754)"
+
+#: ../data/main.ui.h:41
+msgid "Percentage Calculation Tool"
+msgstr "Eina de càlcul de percentatge"
+
+#: ../data/main.ui.h:42 ../data/periodictable.ui.h:1
+msgid "Periodic Table"
+msgstr "Taula periòdica"
+
+#: ../data/main.ui.h:43
+msgid "Minimal Window"
+msgstr "Finestra mìmima"
+
+#: ../data/main.ui.h:44
+msgid "_Quit"
+msgstr "_Surt"
+
+#: ../data/main.ui.h:46
+msgid "Manage Variables"
+msgstr "Gestiona les variables"
+
+#: ../data/main.ui.h:47
+msgid "Manage Functions"
+msgstr "Gestiona les funcions"
+
+#: ../data/main.ui.h:48
+msgid "Manage Units"
+msgstr "Gestiona les unitats"
+
+#: ../data/main.ui.h:49
+msgid "Manage Data Sets"
+msgstr "Gestiona els conjunts de dades"
+
+#: ../data/main.ui.h:50 ../src/interface.cc:1294 ../src/callbacks.cc:1696
+#: ../src/callbacks.cc:27676
+msgid "Factorize"
+msgstr "Factoritza"
+
+#: ../data/main.ui.h:51 ../src/interface.cc:1292 ../src/callbacks.cc:1699
+#: ../src/callbacks.cc:27689
+msgid "Expand"
+msgstr "Expandeix"
+
+#: ../data/main.ui.h:52
+msgid "Apply partial fraction decomposition to the current result."
+msgstr "Aplica la descomposició en fraccions parcials al resultat actual."
+
+#: ../data/main.ui.h:53 ../src/interface.cc:1296
+msgid "Expand Partial Fractions"
+msgstr "Expandeix fraccions parcials"
+
+#: ../data/main.ui.h:54
+msgid "Set Unknowns…"
+msgstr "Estableix les desconegudes…"
+
+#: ../data/main.ui.h:55
+msgid "Convert to Unit"
+msgstr "Converteix a unitat"
+
+#: ../data/main.ui.h:56
+msgid "Set Prefix"
+msgstr "Estableix prefix"
+
+#: ../data/main.ui.h:57
+msgid "Convert to Unit Expression…"
+msgstr "Converteix a una expressió d'unitat…"
+
+#: ../data/main.ui.h:58
+msgid "Convert to Base Units"
+msgstr "Converteix a unitats bases"
+
+#: ../data/main.ui.h:59
+msgid "Convert to Optimal Unit"
+msgstr "Converteix a la unitat òptima"
+
+#: ../data/main.ui.h:60 ../src/callbacks.cc:18485
+msgid "Insert Date…"
+msgstr "Insereix data…"
+
+#: ../data/main.ui.h:61 ../src/callbacks.cc:18486
+msgid "Insert Matrix…"
+msgstr "Insereix matriu…"
+
+#: ../data/main.ui.h:62 ../src/callbacks.cc:18487
+msgid "Insert Vector…"
+msgstr "Insereix vector…"
+
+#: ../data/main.ui.h:63
+msgid "_Copy Result"
+msgstr "_Copia el resultat"
+
+#: ../data/main.ui.h:65
+msgid "Customize Keypad Buttons"
+msgstr "Personalitza els botons de teclat numèric"
+
+#: ../data/main.ui.h:66
+msgid "_Preferences"
+msgstr "_Preferències"
+
+#: ../data/main.ui.h:67
+msgid "_Mode"
+msgstr "_Mode"
+
+#: ../data/main.ui.h:68 ../src/callbacks.cc:18459
+msgid "Number Base"
+msgstr "Base numèrica"
+
+#: ../data/main.ui.h:69
+msgid "Select Result and Expression Base…"
+msgstr "Selecciona la base del resultat i de l'expressió…"
+
+#: ../data/main.ui.h:70 ../data/nbases.ui.h:4 ../data/setbase.ui.h:3
+#: ../src/interface.cc:1491 ../src/callbacks.cc:18462 ../src/callbacks.cc:27157
+#: ../src/callbacks.cc:31082 ../src/callbacks.cc:31122
+msgid "Binary"
+msgstr "Binària"
+
+#: ../data/main.ui.h:71 ../data/nbases.ui.h:5 ../data/setbase.ui.h:4
+#: ../src/interface.cc:1492 ../src/callbacks.cc:18463 ../src/callbacks.cc:27158
+#: ../src/callbacks.cc:31083 ../src/callbacks.cc:31123
+msgid "Octal"
+msgstr "Octal"
+
+#: ../data/main.ui.h:72 ../data/nbases.ui.h:3 ../data/setbase.ui.h:5
+#: ../src/interface.cc:1493 ../src/callbacks.cc:18464 ../src/callbacks.cc:27159
+#: ../src/callbacks.cc:31084 ../src/callbacks.cc:31124
+msgid "Decimal"
+msgstr "Decimal"
+
+#: ../data/main.ui.h:73 ../data/nbases.ui.h:10 ../data/setbase.ui.h:6
+#: ../src/callbacks.cc:18465 ../src/callbacks.cc:27160
+#: ../src/callbacks.cc:31085 ../src/callbacks.cc:31125
+msgid "Duodecimal"
+msgstr "Duodecimal"
+
+#: ../data/main.ui.h:74 ../data/nbases.ui.h:11 ../data/setbase.ui.h:7
+#: ../src/interface.cc:1494 ../src/callbacks.cc:18466 ../src/callbacks.cc:27161
+#: ../src/callbacks.cc:31086 ../src/callbacks.cc:31126
+msgid "Hexadecimal"
+msgstr "Hexadecimal"
+
+#: ../data/main.ui.h:75 ../src/callbacks.cc:18468
+msgid "Other…"
+msgstr "Altra…"
+
+#: ../data/main.ui.h:76 ../data/setbase.ui.h:8 ../src/callbacks.cc:27172
+#: ../src/callbacks.cc:27203
+msgid "Sexagesimal"
+msgstr "Sexagesimal"
+
+#: ../data/main.ui.h:77
+msgid "Time Format"
+msgstr "Format de temps"
+
+#: ../data/main.ui.h:78 ../src/callbacks.cc:18467
+msgid "Roman Numerals"
+msgstr "Nombres romans"
+
+#: ../data/main.ui.h:79
+msgid "Numerical Display"
+msgstr "Presentació numèrica"
+
+#: ../data/main.ui.h:80
+msgid "Normal"
+msgstr "Normal"
+
+#: ../data/main.ui.h:81
+msgid "Engineering"
+msgstr "Enginyeria"
+
+#: ../data/main.ui.h:82
+msgid "Scientific"
+msgstr "Científica"
+
+#: ../data/main.ui.h:83
+msgid "Purely Scientific"
+msgstr "Científica pura"
+
+#: ../data/main.ui.h:84
+msgid "Simple"
+msgstr "Senzill"
+
+#: ../data/main.ui.h:85
+msgid ""
+"Off: 1/7 ≈ 0.14285714\n"
+"On: 1/7 = 0.142857 142857..."
+msgstr ""
+"Desactivat: 1/7 ≈ 0,14285714\n"
+"Activat: 1/7 = 0,142857 142857..."
+
+#: ../data/main.ui.h:87
+msgid "Indicate Repeating Decimals"
+msgstr "Indica els decimals periòdics"
+
+#: ../data/main.ui.h:88
+msgid "Show Ending Zeroes"
+msgstr "Mostra els zeros finals"
+
+#: ../data/main.ui.h:89
+msgid ""
+"Off: 2.5 ≈ 3,  1.5 ≈ 2\n"
+"On: 2.5 ≈ 2, 1.5 ≈ 2"
+msgstr ""
+"Desactivat: 2,5 ≈ 3,  1,5 ≈ 2\n"
+"Activat: 2,5 ≈ 2, 1,5 ≈ 2"
+
+#: ../data/main.ui.h:91
+msgid "Round Halfway Numbers to Even"
+msgstr "Arrodoneix els nombres a mig camí al par"
+
+#: ../data/main.ui.h:92
+msgid ""
+"Off: -x + y\n"
+"On: y - x"
+msgstr ""
+"Desactivat: -x + y\n"
+"Activat: y - x"
+
+#: ../data/main.ui.h:94
+msgid "Sort Minus Last"
+msgstr "Ordena els negatius al final"
+
+#: ../data/main.ui.h:95
+msgid "Complex Rectangular Form"
+msgstr "Forma rectangular complexa"
+
+#: ../data/main.ui.h:96
+msgid "Complex Exponential Form"
+msgstr "Forma exponencial complexa"
+
+#: ../data/main.ui.h:97
+msgid "Complex Polar Form"
+msgstr "Forma polar complexa"
+
+#: ../data/main.ui.h:98
+msgid "Complex Angle/Phasor Notation"
+msgstr "Notació complexa d'angle o de fasor"
+
+#: ../data/main.ui.h:99
+msgid "Rational Number Form"
+msgstr "Forma de nombres racionals"
+
+#: ../data/main.ui.h:100
+msgid "1/3 ≈ 0.33333"
+msgstr "1/3 ≈ 0,33333"
+
+#: ../data/main.ui.h:101
+msgid "Decimal Fractions"
+msgstr "Fraccions decimals"
+
+#: ../data/main.ui.h:102
+msgid ""
+"3/9 = 1/3\n"
+"6/4 = 1.5"
+msgstr ""
+"3/9 = 1/3\n"
+"6/4 = 1,5"
+
+#: ../data/main.ui.h:104
+msgid "Exact Decimal Fractions"
+msgstr "Fraccions decimals exactes"
+
+#: ../data/main.ui.h:105
+msgid "6/4 = 3/2"
+msgstr "6/4 = 3/2"
+
+#: ../data/main.ui.h:106
+msgid "Simple Fractions"
+msgstr "Fraccions senzilles"
+
+#: ../data/main.ui.h:107
+msgid "6/4 = 1+1/2"
+msgstr "6/4 = 1+1/2"
+
+#: ../data/main.ui.h:108
+msgid "Mixed Fractions"
+msgstr "Fraccions mixtes"
+
+#: ../data/main.ui.h:109
+msgid "Interval Display"
+msgstr "Presentació d'intervals"
+
+#: ../data/main.ui.h:110
+msgid ""
+"Off: 1/2*pi ≈ 1.5707963\n"
+"On: 1/2*pi = 0.5 pi"
+msgstr ""
+"Desactivat: 1/2*pi ≈ 1,5707963\n"
+"Activat: 1/2*pi = 0.5 pi"
+
+#: ../data/main.ui.h:112
+msgid "Adaptive"
+msgstr "Adaptativa"
+
+#: ../data/main.ui.h:113
+msgid ""
+"Calculates an interval of possible values and keeps track of precision "
+"changes."
+msgstr ""
+"Calcula un interval de valors possibles i rastreja els canvis de precisió."
+
+#: ../data/main.ui.h:114
+msgid "Significant Digits"
+msgstr "Xifres significants"
+
+#: ../data/main.ui.h:115 ../src/interface.cc:1032 ../src/interface.cc:3996
+msgid "Interval"
+msgstr "Interval"
+
+#: ../data/main.ui.h:116
+msgid "Plus/Minus"
+msgstr "Més/Menys"
+
+#: ../data/main.ui.h:117
+msgid "Midpoint"
+msgstr "Punt mitjà"
+
+#: ../data/main.ui.h:118
+msgid "Unit Display"
+msgstr "Presentació d'unitats"
+
+#: ../data/main.ui.h:119
+msgid "Do not use any prefixes in result"
+msgstr "No usis cap prefix en el resultat"
+
+#: ../data/main.ui.h:120
+msgid "Show prefixes for primarily SI and CGS units."
+msgstr "Mostra els prefixes per a unitats principalment SI i CGS."
+
+#: ../data/main.ui.h:121
+msgid "Use prefixes for selected units"
+msgstr "Usa prefixes per a les unitats seleccionades"
+
+#: ../data/main.ui.h:122
+msgid "Use prefixes also for currencies"
+msgstr "Usa prefixes també per a les monedes"
+
+#: ../data/main.ui.h:123
+msgid "Use prefixs for all units"
+msgstr "Usa prefixes per a totes les unitats"
+
+#: ../data/main.ui.h:124
+msgid ""
+"Enables automatic use of hekto, deka, deci and centi when prefixes are "
+"enabled"
+msgstr ""
+"Habilita l'ús automàtic de hecto, deka, deci i centi quan els prefixes estén "
+"habilitades"
+
+#: ../data/main.ui.h:125
+msgid "Enable All SI Prefixes"
+msgstr "Habilita tots els prefixes SI"
+
+#: ../data/main.ui.h:126
+msgid ""
+"Enables automatic setting of prefix for denominator in addition to the "
+"numerator"
+msgstr ""
+"Habilita l'establiment automàtic del prefix del denominador a més del "
+"numerador"
+
+#: ../data/main.ui.h:127
+msgid "Enable Denominator Prefixes"
+msgstr "Habilita els prefixes de denominador"
+
+#: ../data/main.ui.h:128
+msgid ""
+"Off: J / K\n"
+"On: J * K^-1"
+msgstr ""
+"Desactivat: J / K\n"
+"Activat: J * K^-1"
+
+#: ../data/main.ui.h:130
+msgid "Negative Exponents"
+msgstr "Exponents negatius"
+
+#: ../data/main.ui.h:131
+msgid ""
+"Off: (2 m)/s\n"
+"On: 2 (m/s)"
+msgstr ""
+"Desactivat: (2 m)/s\n"
+"Activat: 2 (m/s)"
+
+#: ../data/main.ui.h:133
+msgid "Place Units Separately"
+msgstr "Separa les unitats"
+
+#: ../data/main.ui.h:134
+msgid "No Additional Conversion"
+msgstr "Cap conversió addicional"
+
+#: ../data/main.ui.h:135
+msgid "Convert to Optimal SI Unit"
+msgstr "Converteix a la unitat SI òptima"
+
+#: ../data/main.ui.h:136
+msgid ""
+"If enabled:\n"
+"15 in = 1 ft + 3 in\n"
+"3.2 h = 3 h + 12 min"
+msgstr ""
+"Si està habilitat:\n"
+"15 in = 1 ft + 3 in\n"
+"3.2 h = 3 h + 12 min"
+
+#: ../data/main.ui.h:139
+msgid "Convert to Mixed Units"
+msgstr "Converteix a unitats mixtes"
+
+#: ../data/main.ui.h:140
+msgid "Abbreviate Names"
+msgstr "Abrevia els noms"
+
+#: ../data/main.ui.h:141
+msgid "Enabled Objects"
+msgstr "Objectes habilitats"
+
+#: ../data/main.ui.h:142 ../data/variables.ui.h:1
+msgid "Variables"
+msgstr "Variables"
+
+#: ../data/main.ui.h:144 ../data/units.ui.h:1
+msgid "Units"
+msgstr "Unitats"
+
+#: ../data/main.ui.h:145
+msgid "Unknowns"
+msgstr "Desconegudes"
+
+#: ../data/main.ui.h:146
+msgid "Units in Physical Constants"
+msgstr "Unitats en constants físics"
+
+#: ../data/main.ui.h:147
+msgid "If not enabled, treats all variables as unknown"
+msgstr "Si no està habilitat, tracta totes les variables com a desconegudes"
+
+#: ../data/main.ui.h:148
+msgid "Calculate Variables"
+msgstr "Calcula les variables"
+
+#: ../data/main.ui.h:149
+msgid "Disables/enables complex numbers in result"
+msgstr "Deshabilita/habilita els nombres complexes en el resultat"
+
+#: ../data/main.ui.h:150
+msgid "Allow Complex Result"
+msgstr "Permet un result complex"
+
+#: ../data/main.ui.h:151
+msgid "Disables/enables infinite numbers in result"
+msgstr "Deshabilita/habilita nombres infinits en el resultat"
+
+#: ../data/main.ui.h:152
+msgid "Allow Infinite Result"
+msgstr "Permet resultat d'infinit"
+
+#: ../data/main.ui.h:153
+msgid "Approximation"
+msgstr "Aproximació"
+
+#: ../data/main.ui.h:154
+msgid "Always Exact"
+msgstr "Sempre sigues exacte"
+
+#: ../data/main.ui.h:155
+msgid "Try Exact"
+msgstr "Intenta ser exacte"
+
+#: ../data/main.ui.h:156 ../src/callbacks.cc:16891
+msgid "Approximate"
+msgstr "Aproxima"
+
+#: ../data/main.ui.h:157
+msgid "Interval Arithmetic"
+msgstr "Aritmètica d'interval"
+
+#: ../data/main.ui.h:158
+msgid "Interval Calculation"
+msgstr "Càlcul d'interval"
+
+#: ../data/main.ui.h:159
+msgid "Variance Formula"
+msgstr "Fórmula de variància"
+
+#: ../data/main.ui.h:160
+msgid "Change angle unit used in trigonometric functions"
+msgstr "Canvia la unitat d'angle que s'usa en les funcions trigonomètriques"
+
+#: ../data/main.ui.h:161
+msgid "Angle Unit"
+msgstr "Unitat d'angle"
+
+#: ../data/main.ui.h:162 ../data/plot.ui.h:26 ../src/interface.cc:4088
+msgid "None"
+msgstr "Cap"
+
+#: ../data/main.ui.h:163
+msgid "Assumptions"
+msgstr "Suposicions"
+
+#: ../data/main.ui.h:164
+msgid "Algebraic Mode"
+msgstr "Mode algebraic"
+
+#: ../data/main.ui.h:165
+msgid "Assume that unknown denominators are non-zero"
+msgstr "Presumeix que els denominadors desconeguts no siguin zero"
+
+#: ../data/main.ui.h:166
+msgid "Non-Zero Denominators"
+msgstr "Denominadors no zero"
+
+#: ../data/main.ui.h:167
+msgid "Warn when unknown denominators are assumed non-zero"
+msgstr ""
+"Adverteix quan es presumeix que els denominadors desconeguts no siguin zero"
+
+#: ../data/main.ui.h:168
+msgid "Warn About Denominators Assumed Non-Zero"
+msgstr "Adverteix en quant als denominadors presumiblement no zeros"
+
+#: ../data/main.ui.h:169 ../src/callbacks.cc:18449
+msgid "Parsing Mode"
+msgstr "Mode d'anàlisi"
+
+#: ../data/main.ui.h:170
+msgid "Adaptive Parsing"
+msgstr "Anàlisi adaptiva"
+
+#: ../data/main.ui.h:171
+msgid "Parse Implicit Multiplication First"
+msgstr "Analitza primer la multiplicació implícita"
+
+#: ../data/main.ui.h:172
+msgid "Conventional Parsing"
+msgstr "Anàlisi convencional"
+
+#: ../data/main.ui.h:173
+msgid "Chain Syntax"
+msgstr "Sintaxi de cadena"
+
+#: ../data/main.ui.h:174
+msgid "RPN Syntax"
+msgstr "Sintaxi NPI"
+
+#: ../data/main.ui.h:175
+msgid ""
+"Off: xy = x*y\n"
+"On: xy != x*y"
+msgstr ""
+"Desactivat: xy = x*y\n"
+"Activat: xy != x*y"
+
+#: ../data/main.ui.h:177
+msgid "Limit Implicit Multiplication"
+msgstr "Limita la multiplicació implícita"
+
+#: ../data/main.ui.h:178
+msgid ""
+"Parse decimal numbers as approximate with precision equal to the number of "
+"digits.\n"
+"\n"
+"Off: 1.1 * 1.1 = 1.21\n"
+"On: 1.1 * 1.1 ≈ 1.2"
+msgstr ""
+"Analitza els nombres decimals com a aproximats amb precisió igual al nombre "
+"de xifres.\n"
+"\n"
+"Desactivat: 1.1 * 1.1 = 1.21\n"
+"Activat: 1.1 * 1.1 ≈ 1.2"
+
+#: ../data/main.ui.h:182
+msgid "Read Precision"
+msgstr "Llegeix la precisió"
+
+#: ../data/main.ui.h:183
+msgid "_Precision"
+msgstr "_Precisió"
+
+#: ../data/main.ui.h:184
+msgid "_Decimals"
+msgstr "_Decimals"
+
+#: ../data/main.ui.h:185
+msgid "Calculate As You Type"
+msgstr "Calcula mentre teclegeu"
+
+#: ../data/main.ui.h:186
+msgid "Chain Mode"
+msgstr "Mode de cadena"
+
+#: ../data/main.ui.h:187
+msgid "Activate the RPN stack."
+msgstr "Activa la pila NPI."
+
+#: ../data/main.ui.h:188
+msgid "RPN Mode"
+msgstr "Mode NPI"
+
+#: ../data/main.ui.h:189 ../src/callbacks.cc:18470
+msgid "Meta Modes"
+msgstr "Metamodes"
+
+#: ../data/main.ui.h:190 ../src/callbacks.cc:18482
+msgid "Save Mode…"
+msgstr "Desa el mode…"
+
+#: ../data/main.ui.h:191
+msgid "Delete Mode…"
+msgstr "Suprimeix el mode…"
+
+#: ../data/main.ui.h:192
+msgid "Save Default _Mode"
+msgstr "Desa com al _mode predeterminat"
+
+#: ../data/main.ui.h:193
+msgid "Fu_nctions"
+msgstr "Fu_ncions"
+
+#: ../data/main.ui.h:194
+msgid "_Variables"
+msgstr "_Variables"
+
+#: ../data/main.ui.h:195
+msgid "_Units"
+msgstr "_Unitats"
+
+#: ../data/main.ui.h:197
+msgid "_Contents"
+msgstr "_Continguts"
+
+#: ../data/main.ui.h:198
+msgid "Report a Bug"
+msgstr "Informa d'un error"
+
+#: ../data/main.ui.h:199
+msgid "Check for Updates"
+msgstr "Cercar actualitzacions"
+
+#: ../data/main.ui.h:200
+msgid "_About"
+msgstr "_Quant al"
+
+#: ../data/main.ui.h:201 ../src/callbacks.cc:6207
+msgid "Toggle minimal window"
+msgstr "Commuta la finestra mínima"
+
+#: ../data/main.ui.h:202
+msgid "Calculation result"
+msgstr "Resultat del càlcul"
+
+#: ../data/main.ui.h:203
+msgid "_Keypad"
+msgstr "_Teclat numèric"
+
+#: ../data/main.ui.h:204
+msgid ""
+"Toggles persistent keypad (makes it possible to show keypad and history "
+"simultaneously)"
+msgstr ""
+"Commuta el teclat numèric persistent (fa possible mostrar el teclat numèric "
+"i l'historial simultàniament)"
+
+#: ../data/main.ui.h:205
+msgid "_History"
+msgstr "_Historial"
+
+#: ../data/main.ui.h:206
+msgid "C_onversion"
+msgstr "C_onversió"
+
+#: ../data/main.ui.h:207
+msgid "RPN Stack"
+msgstr "Pila NPI"
+
+#: ../data/main.ui.h:208
+msgid "Insert the selected value"
+msgstr "Insereix el valor seleccionat"
+
+#: ../data/main.ui.h:209
+msgid "Insert the selected text"
+msgstr "Insereix el text seleccionat"
+
+#: ../data/main.ui.h:210
+msgid "Copy the selected text"
+msgstr "Copia el text seleccionat"
+
+#: ../data/main.ui.h:211
+msgid "Add the selected value(s)"
+msgstr "Addiciona el(s) valor(s) seleccionat(s)"
+
+#: ../data/main.ui.h:212
+msgid "Subtract the selected value(s)"
+msgstr "Sostreu el(s) valor(s) seleccionat(s)"
+
+#: ../data/main.ui.h:213
+msgid "Multiply the selected value(s)"
+msgstr "Multiplica el(s) valor(s) seleccionat(s)"
+
+#: ../data/main.ui.h:214
+msgid "Divide the the selected value(s)"
+msgstr "Divideix el(s) valor(s) seleccionat(s)"
+
+#: ../data/main.ui.h:215
+msgid "Raise to the power of the selected value"
+msgstr "Exponencia al valor seleccionat"
+
+#: ../data/main.ui.h:216
+msgid "Calculate the square root of the selected value"
+msgstr "Calcula l'arrel quadrada del valor seleccionat"
+
+#: ../data/main.ui.h:217 ../src/interface.cc:2079
+msgid "History"
+msgstr "Historial"
+
+#: ../data/main.ui.h:219
+msgid "Subtract the top value from the second value"
+msgstr "Sostreu el últim valor del penúltim"
+
+#: ../data/main.ui.h:220
+msgid "Multiply the top two values"
+msgstr "Multiplica el dos últims valors"
+
+#: ../data/main.ui.h:221
+msgid "Divide the second value by the top value"
+msgstr "Divideix el penúltim valor pel últim"
+
+#: ../data/main.ui.h:222
+msgid "Raise the second value to the power of the top value"
+msgstr "Exponencia el penúltim valor al últim"
+
+#: ../data/main.ui.h:223
+msgid "Negate the top value (Ctrl+-)"
+msgstr "Negar el últim valor (Ctrl+-)"
+
+#: ../data/main.ui.h:224
+msgid "Invert the top value"
+msgstr "Inverteix el últim valor"
+
+#: ../data/main.ui.h:225
+msgid "Calculate the square root of the top value"
+msgstr "Calcula l'arrel quadrada del últim valor"
+
+#: ../data/main.ui.h:226
+msgid "Calculate the sum of all values"
+msgstr "Calcula la suma de tots els valors"
+
+#: ../data/main.ui.h:227 ../src/callbacks.cc:6302
+msgid "Rotate the stack or move selected register up"
+msgstr "Roda la pila o mou el registre seleccionat amunt"
+
+#: ../data/main.ui.h:228 ../src/callbacks.cc:6310
+msgid "Rotate the stack or move selected register down"
+msgstr "Roda la pila o mou el registre seleccionat avall"
+
+#: ../data/main.ui.h:229 ../src/callbacks.cc:6318
+msgid ""
+"Swap the two top values or move the selected value to the top of the stack"
+msgstr ""
+"Intercanvia els últims dos valors o mou el valor seleccionat al cim de la "
+"pila"
+
+#: ../data/main.ui.h:230 ../src/callbacks.cc:6326
+msgid "Copy the selected or top value to the top of the stack"
+msgstr "Copia el valor seleccionat o el últim al cim de la pila"
+
+#: ../data/main.ui.h:231 ../src/callbacks.cc:6334
+msgid "Enter the top value from before the last numeric operation"
+msgstr "Introdueix el úlim valor d'abans de la darrera operació numèrica"
+
+#: ../data/main.ui.h:232 ../src/callbacks.cc:6342
+msgid "Delete the top or selected value"
+msgstr "Suprimeix el últim valor o el seleccionat"
+
+#: ../data/main.ui.h:233
+msgid "Edit the selected value"
+msgstr "Edita el valor seleccionat"
+
+#: ../data/main.ui.h:234 ../src/callbacks.cc:6350
+msgid "Clear the RPN stack"
+msgstr "Neteja la pila NPI"
+
+#: ../data/main.ui.h:236
+msgid "Unit(s) and prefix to convert result to"
+msgstr "Unitat(s) i prefix als quals convertir el resultat"
+
+#: ../data/main.ui.h:238
+msgid "Convert"
+msgstr "Converteix"
+
+#: ../data/main.ui.h:239
+msgid "Continuous conversion"
+msgstr "Conversió contínua"
+
+#: ../data/main.ui.h:240
+msgid ""
+"Automatically convert result to the current unit expression as long as the "
+"conversion box is visible."
+msgstr ""
+"Automàticament converteix el resultat a l'expressió d'unitat actual sempre "
+"que la caixa de conversió sigui visible."
+
+#: ../data/main.ui.h:241
+msgid "Add prefix"
+msgstr "Afegeix un prefix"
+
+#: ../data/main.ui.h:242
+msgid ""
+"If unit expression does not contain any prefixes, use optimal prefix.\n"
+"\n"
+"This can be overridden by prepending the unit expression with \"?\" or \"0\"."
+msgstr ""
+"Si l'expressió d'unitat no conté cap prefix, usa el prefix òptim. \n"
+"\n"
+"Això es pot anular preposant l'expressió d'unitat amb \"?\" o \"0\"."
+
+#: ../data/main.ui.h:245
+msgid "Conversion"
+msgstr "Conversió"
+
+#: ../data/main.ui.h:246 ../src/callbacks.cc:6382
+msgid "Show/hide programming keypad"
+msgstr "Mostra/amaga el teclat programari"
+
+#: ../data/main.ui.h:247 ../src/callbacks.cc:16892
+msgid "Exact"
+msgstr "Exacte"
+
+#: ../data/main.ui.h:248 ../src/callbacks.cc:7255 ../src/callbacks.cc:27181
+msgid "Fraction"
+msgstr "Fracció"
+
+#: ../data/main.ui.h:249
+msgid "Numerical display"
+msgstr "Presentació numèrica"
+
+#: ../data/main.ui.h:250
+msgid "Pure"
+msgstr "Pura"
+
+#: ../data/main.ui.h:251 ../src/callbacks.cc:7227
+msgid "Number base"
+msgstr "Base numèrica"
+
+#: ../data/main.ui.h:252 ../data/setbase.ui.h:9 ../src/callbacks.cc:7279
+#: ../src/callbacks.cc:27173
+msgid "Time format"
+msgstr "Format de temps"
+
+#: ../data/main.ui.h:253 ../src/callbacks.cc:27163
+msgid "Roman"
+msgstr "Romana"
+
+#: ../data/main.ui.h:254
+msgid "sin"
+msgstr "sin"
+
+#: ../data/main.ui.h:255
+msgid "cos"
+msgstr "cos"
+
+#: ../data/main.ui.h:256
+msgid "tan"
+msgstr "tan"
+
+#: ../data/main.ui.h:257
+msgid "ln"
+msgstr "ln"
+
+#: ../data/main.ui.h:258
+msgid "Equals"
+msgstr "És"
+
+#: ../data/main.ui.h:259
+msgid "sqrt"
+msgstr "arrelq"
+
+#: ../data/main.ui.h:260
+msgid "sum"
+msgstr "suma"
+
+#: ../data/main.ui.h:261
+msgid "Unknown variable"
+msgstr "Variable desconeguda"
+
+#: ../data/main.ui.h:262
+msgid "mod"
+msgstr "mod"
+
+#: ../data/main.ui.h:264
+msgid "mean"
+msgstr "mitjana"
+
+#: ../data/main.ui.h:265 ../src/interface.cc:1496
+msgid "Store result as a variable"
+msgstr "Desa el resultat com a variable"
+
+#. Standard calculator button. Do not use more than three characters.
+#: ../data/main.ui.h:267
+msgid "STO"
+msgstr "STO"
+
+#: ../data/main.ui.h:268
+msgid "Convert number bases"
+msgstr "Converteix entre bases numèriques"
+
+#: ../data/main.ui.h:269
+msgid "Imaginary unit i (√-1)"
+msgstr "Unitat imaginària i (√-1)"
+
+#: ../data/main.ui.h:270 ../src/callbacks.cc:6210
+msgid "Manage units"
+msgstr "Gestiona les unitats"
+
+#: ../data/main.ui.h:272
+msgid "Conversion operator"
+msgstr "Operador de conversió"
+
+#: ../data/main.ui.h:274
+msgid "Kilogram"
+msgstr "Quilograma"
+
+#: ../data/main.ui.h:275
+msgid "Two's complement input"
+msgstr "Entrada de complement a dos"
+
+#: ../data/main.ui.h:276
+msgid "Two's complement output"
+msgstr "Sortida de complement a dos"
+
+#: ../data/main.ui.h:277 ../data/nbases.ui.h:25 ../src/interface.cc:1090
+#: ../src/interface.cc:1172 ../src/interface.cc:1498 ../src/interface.cc:1499
+#: ../src/interface.cc:4017 ../src/callbacks.cc:21896 ../src/callbacks.cc:21897
+msgid "Bitwise Exclusive OR"
+msgstr "OR exclusiu bit a bit"
+
+#: ../data/main.ui.h:278 ../data/nbases.ui.h:31 ../src/interface.cc:1168
+msgid "Bitwise Left Shift"
+msgstr "Desplaçament a l'esquerra bit a bit"
+
+#: ../data/main.ui.h:279 ../data/nbases.ui.h:32 ../src/interface.cc:1169
+msgid "Bitwise Right Shift"
+msgstr "Desplaçament a la dreta bit a bit"
+
+#: ../data/main.ui.h:280
+msgid "Floating point conversion"
+msgstr "Conversió de punt flotant"
+
+#: ../data/main.ui.h:281
+msgid "Show/hide left keypad"
+msgstr "Mostra/amaga el teclat numèric esquerre"
+
+#: ../data/main.ui.h:282
+msgid "Show/hide right keypad"
+msgstr "Mostra/amaga el teclat numèric dret"
+
+#. Standard calculator button. Do not use more than three characters.
+#: ../data/main.ui.h:284 ../data/nbases.ui.h:28 ../src/interface.cc:1097
+msgid "DEL"
+msgstr "DEL"
+
+#. Standard calculator button. Do not use more than three characters.
+#: ../data/main.ui.h:286 ../data/nbases.ui.h:30 ../src/interface.cc:1096
+msgid "AC"
+msgstr "AC"
+
+#: ../data/main.ui.h:287 ../src/interface.cc:1098 ../src/interface.cc:4024
+msgid "Previous result"
+msgstr "Resultat prèvi"
+
+#. Standard calculator button. Do not use more than three characters.
+#: ../data/main.ui.h:289 ../src/interface.cc:1098
+msgid "ANS"
+msgstr "ANS"
+
+#: ../data/main.ui.h:290 ../src/interface.cc:1051
+msgid "EXP"
+msgstr "EXP"
+
+#: ../data/main.ui.h:291
+msgid "Add to Expression"
+msgstr "Afegeix a l'expressió"
+
+#: ../data/main.ui.h:292
+msgid "Persistent Keypad"
+msgstr "Teclat numèric persistent"
+
+#: ../data/main.ui.h:293
+msgid "Edit"
+msgstr "Edita"
+
+#: ../data/main.ui.h:294 ../data/nbases.ui.h:27 ../src/interface.cc:1097
+#: ../src/interface.cc:4023
+msgid "Delete"
+msgstr "Suprimeix"
+
+#: ../data/main.ui.h:295
+msgid "Update"
+msgstr "Actualitza"
+
+#: ../data/main.ui.h:296
+msgid "Insert Value"
+msgstr "Insereix el valor"
+
+#: ../data/main.ui.h:297
+msgid "Insert Text"
+msgstr "Insereix el text"
+
+#: ../data/main.ui.h:298
+msgid "Insert Parsed Text"
+msgstr "Insereix el text analitzat"
+
+#: ../data/main.ui.h:299 ../src/searchprovider.cc:243
+msgid "Copy"
+msgstr "Copia"
+
+#: ../data/main.ui.h:300
+msgid "Copy Full Text"
+msgstr "Copia el text complet"
+
+#: ../data/main.ui.h:301
+msgid "Search…"
+msgstr "Cerca…"
+
+#: ../data/main.ui.h:302 ../src/callbacks.cc:26288
+msgid "Add Bookmark…"
+msgstr "Afegeix un marcador…"
+
+#: ../data/main.ui.h:303
+msgid "Bookmarks"
+msgstr "Marcadors"
+
+#: ../data/main.ui.h:304
+msgid "Protect"
+msgstr "Protegeix"
+
+#: ../data/main.ui.h:305
+msgid "Move To Top"
+msgstr "Mou al cim"
+
+#: ../data/main.ui.h:306
+msgid "Remove"
+msgstr "Elimina"
+
+#: ../data/main.ui.h:307
+msgid "Clear All"
+msgstr "Neteja tot"
+
+#: ../data/main.ui.h:308
+msgid "_Copy"
+msgstr "_Copia"
+
+#: ../data/main.ui.h:309
+msgid "_Store…"
+msgstr "_Desa…"
+
+#: ../data/main.ui.h:310
+msgid "Save Image…"
+msgstr "Desa una imatge…"
+
+#: ../data/main.ui.h:311
+msgid "_Factorize"
+msgstr "_Factoritza"
+
+#: ../data/main.ui.h:312
+msgid "_Expand"
+msgstr "_Expandeix"
+
+#: ../data/main.ui.h:313
+msgid "_Normal"
+msgstr "_Normal"
+
+#: ../data/main.ui.h:314
+msgid "Sc_ientific"
+msgstr "C_ientífica"
+
+#: ../data/main.ui.h:315
+msgid "Purel_y Scientific"
+msgstr "Cientifica P_ura"
+
+#: ../data/main.ui.h:316
+msgid "Simp_le"
+msgstr "Senzi_lla"
+
+#: ../data/main.ui.h:317
+msgid "_Binary"
+msgstr "_Binaria"
+
+#: ../data/main.ui.h:318
+msgid "_Octal"
+msgstr "_Octal"
+
+#: ../data/main.ui.h:319
+msgid "_Decimal"
+msgstr "_Decimal"
+
+#: ../data/main.ui.h:320
+msgid "_Hexadecimal"
+msgstr "_Hexadecimal"
+
+#: ../data/main.ui.h:321
+msgid "Decimal Fraction"
+msgstr "Fracció decimal"
+
+#: ../data/main.ui.h:322
+msgid "Exact Decimal Fraction"
+msgstr "Fracció decimal exacta"
+
+#: ../data/main.ui.h:323
+msgid "Simple Fraction"
+msgstr "Fracció senzilla"
+
+#: ../data/main.ui.h:324
+msgid "Mixed Fraction"
+msgstr "Fracció mixta"
+
+#: ../data/main.ui.h:325
+msgid "_Abbreviate Names"
+msgstr "_Abrevia els noms"
+
+#: ../data/main.ui.h:326
+msgid "C_onvert…"
+msgstr "C_onverteix…"
+
+#: ../data/main.ui.h:327
+msgid "Convert to Base _Units"
+msgstr "Converteix a _unitats bases"
+
+#: ../data/main.ui.h:328
+msgid "Convert _to Optimal Unit"
+msgstr "Converteix a la unitat òp_tima"
+
+#: ../data/main.ui.h:329
+msgid "Use Optimal Prefix"
+msgstr "Usa el prefix òptim"
+
+#: ../data/main.ui.h:330
+msgid "Convert to"
+msgstr "Converteix a"
+
+#: ../data/main.ui.h:331
+msgid "Convert to UTC"
+msgstr "Converteix a UTC"
+
+#: ../data/main.ui.h:332
+msgid "Convert to Calendars"
+msgstr "Converteix entre calendaris"
+
+#: ../data/main.ui.h:333
+msgid "Use prefixes for all units"
+msgstr "Usa prefixes per a totes les unitats"
+
+#: ../data/main.ui.h:334
+msgid "Enable All SI Prefi_xes"
+msgstr "Habilita tots els prefi_xes SI"
+
+#: ../data/main.ui.h:335
+msgid "View/Edit Matrix"
+msgstr "Visualitza/edita la matriu"
+
+#: ../data/main.ui.h:336
+msgid "View/Edit Vector"
+msgstr "Visualitza/edita el vector"
+
+#: ../data/main.ui.h:337
+msgid "Copy Text"
+msgstr "Copia el text"
+
+#: ../data/main.ui.h:338
+msgid "To Top"
+msgstr "Al cim"
+
+#: ../data/main.ui.h:339
+msgid "Swap"
+msgstr "Intercanvia"
+
+#: ../data/main.ui.h:340
+msgid "Up"
+msgstr "Amunt"
+
+#: ../data/main.ui.h:341
+msgid "Down"
+msgstr "Avall"
+
+#: ../data/main.ui.h:342
+msgid "Negate"
+msgstr "Nega"
+
+#: ../data/main.ui.h:343
+msgid "Invert"
+msgstr "Inverteix"
+
+#: ../data/main.ui.h:344
+msgid "Square"
+msgstr "Quadra"
+
+#: ../data/main.ui.h:345
+msgid "Square Root"
+msgstr "Arrel quadrada"
+
+#: ../data/main.ui.h:346
+msgid "Clear Stack"
+msgstr "Neteja la pila"
+
+#: ../data/main.ui.h:347
+msgid "Select Number Base…"
+msgstr "Selecciona la base numèrica…"
+
+#: ../data/main.ui.h:348 ../src/callbacks.cc:6212
+msgid "Store result"
+msgstr "Desa el resultat"
+
+#. Add current result to variable value
+#: ../data/main.ui.h:350
+msgid "Add result"
+msgstr "Addiciona el resultat"
+
+#. Subtruct current result from variable value
+#: ../data/main.ui.h:352
+msgid "Subtract result"
+msgstr "Sostreu el resultat"
+
+#: ../data/matrix.ui.h:5
+msgid "Insert the matrix/vector into the expression"
+msgstr "Insereix la matriu o el vector en l'expressió"
+
+#: ../data/matrix.ui.h:6 ../data/matrixedit.ui.h:14 ../data/plot.ui.h:12
+msgid "Rows"
+msgstr "Files"
+
+#: ../data/matrix.ui.h:7 ../data/matrixedit.ui.h:15
+msgid "Number of rows in this matrix (rows displayed for vectors)"
+msgstr "Nombre de files en aquesta matriu (files mostrades per als vectors)"
+
+#: ../data/matrix.ui.h:8 ../data/matrixedit.ui.h:16
+msgid "Columns"
+msgstr "Columnes"
+
+#: ../data/matrix.ui.h:9 ../data/matrixedit.ui.h:17
+msgid "Number of columns in this matrix (columns displayed for vectors)"
+msgstr ""
+"Nombre de columnes en aquesta matriu (columnes mostrades per als vectors)"
+
+#: ../data/matrix.ui.h:10 ../data/matrixedit.ui.h:19
+msgid "If this is a matrix or vector"
+msgstr "Si això és una matriu o un vector"
+
+#: ../data/matrix.ui.h:12 ../data/matrixedit.ui.h:21 ../src/callbacks.cc:33092
+#: ../src/callbacks.cc:33100 ../src/callbacks.cc:33108
+#: ../src/callbacks.cc:33116
+msgid "Elements"
+msgstr "Elements"
+
+#: ../data/matrix.ui.h:13 ../data/matrixedit.ui.h:22
+msgid "Current element:"
+msgstr "Element actual:"
+
+#: ../data/matrixedit.ui.h:1 ../src/callbacks.cc:16427
+msgid "Edit Matrix"
+msgstr "Edició de matriu"
+
+#: ../data/matrixedit.ui.h:4
+msgid "Do not create/modify this matrix/vector"
+msgstr "No creis/modifiques aquesta matriu o aquest vector"
+
+#: ../data/matrixedit.ui.h:6
+msgid "Create/modify the matrix/vector"
+msgstr "Crea/modifica la matriu o el vector"
+
+#: ../data/matrixedit.ui.h:7
+msgid "Accept the creation/modification of this matrix/vector"
+msgstr "Accepta la creació/modificació d'aquesta matriu o d'aquest vector"
+
+#: ../data/matrixedit.ui.h:9 ../data/simplefunctionedit.ui.h:7
+#: ../data/variableedit.ui.h:7
+msgid "Name used to reference this variable in expressions"
+msgstr "Nom usat per a referir a aquesta variable en les expressions"
+
+#: ../data/namesedit.ui.h:1
+msgid "Names"
+msgstr "Noms"
+
+#: ../data/namesedit.ui.h:4
+msgid "Add new name"
+msgstr "Afegeix un nom nou"
+
+#: ../data/namesedit.ui.h:5
+msgid "Apply changes to the selected name"
+msgstr "Aplica els canvis al nom seleccionat"
+
+#: ../data/namesedit.ui.h:6
+msgid "Remove the selected name"
+msgstr "Elimina el nom seleccionat"
+
+#: ../data/namesedit.ui.h:7 ../src/interface.cc:3145
+msgid "Abbreviation"
+msgstr "Abreviatura"
+
+#: ../data/namesedit.ui.h:8 ../src/callbacks.cc:3809 ../src/callbacks.cc:7281
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../data/namesedit.ui.h:9 ../src/interface.cc:3149
+msgid "Plural"
+msgstr "Plural"
+
+#: ../data/namesedit.ui.h:10
+msgid "Suffix"
+msgstr "Sufix"
+
+#: ../data/namesedit.ui.h:11 ../src/interface.cc:2861 ../src/interface.cc:3153
+msgid "Reference"
+msgstr "Referència"
+
+#: ../data/namesedit.ui.h:12
+msgid "Avoid input"
+msgstr "Evita l'entrada"
+
+#: ../data/namesedit.ui.h:13
+msgid "Case sensitive"
+msgstr "Distingeix entre majúscules i minúscules"
+
+#: ../data/namesedit.ui.h:14
+msgid "Completion only"
+msgstr "Només compleció"
+
+#: ../data/nbases.ui.h:1 ../data/setbase.ui.h:1
+msgid "Number Bases"
+msgstr "Bases numèriques"
+
+#: ../data/nbases.ui.h:9 ../data/setbase.ui.h:10 ../src/callbacks.cc:7275
+#: ../src/callbacks.cc:31087 ../src/callbacks.cc:31127
+msgid "Roman numerals"
+msgstr "Numerals romans"
+
+#: ../data/nbases.ui.h:13 ../src/callbacks.cc:1978
+msgid "BIN"
+msgstr "BIN"
+
+#: ../data/nbases.ui.h:14 ../src/callbacks.cc:1983
+msgid "OCT"
+msgstr "OCT"
+
+#: ../data/nbases.ui.h:15
+msgid "DEC"
+msgstr "DEC"
+
+#: ../data/nbases.ui.h:16 ../src/callbacks.cc:1988
+msgid "DUO"
+msgstr "DUO"
+
+#: ../data/nbases.ui.h:17 ../src/callbacks.cc:1993
+msgid "HEX"
+msgstr "HEX"
+
+#: ../data/nbases.ui.h:18
+msgid "ROM"
+msgstr "ROM"
+
+#: ../data/nbases.ui.h:20 ../src/interface.cc:1094 ../src/interface.cc:4021
+msgid "Subtract"
+msgstr "Sostreu"
+
+#: ../data/nbases.ui.h:21 ../src/interface.cc:1090 ../src/interface.cc:4017
+msgid "Multiply"
+msgstr "Multiplica"
+
+#: ../data/nbases.ui.h:22 ../src/interface.cc:1089 ../src/interface.cc:4016
+msgid "Divide"
+msgstr "Divideix"
+
+#: ../data/nbases.ui.h:23 ../src/interface.cc:1091 ../src/interface.cc:1170
+#: ../src/interface.cc:1487 ../src/interface.cc:4018
+msgid "Bitwise AND"
+msgstr "AND bit a bit"
+
+#: ../data/nbases.ui.h:24 ../src/interface.cc:1094 ../src/interface.cc:1171
+#: ../src/interface.cc:1488 ../src/interface.cc:4021
+msgid "Bitwise OR"
+msgstr "OR bit a bit"
+
+#: ../data/nbases.ui.h:26 ../src/interface.cc:1173 ../src/interface.cc:1489
+msgid "Bitwise NOT"
+msgstr "NOT bit a bit"
+
+#: ../data/nbases.ui.h:29 ../data/percentage.ui.h:4 ../src/interface.cc:1096
+#: ../src/interface.cc:4022 ../src/callbacks.cc:18403
+msgid "Clear"
+msgstr "Neteja"
+
+#: ../data/percentage.ui.h:1
+msgid ""
+"Enter two values, of which at most one is a percentage, and the others will "
+"be calculated for you."
+msgstr ""
+"Introduïu dos valors, dels quals al màxim un és percentatge, i es calcularan "
+"els altres per a vostè."
+
+#: ../data/percentage.ui.h:2
+msgid "Percentage"
+msgstr "Porcentatge"
+
+#: ../data/percentage.ui.h:3
+msgid "Calculate"
+msgstr "Calcula"
+
+#: ../data/percentage.ui.h:6
+msgid "Value 1"
+msgstr "Valor 1"
+
+#: ../data/percentage.ui.h:7
+msgid "2 compared to 1"
+msgstr "2 comparat amb 1"
+
+#: ../data/percentage.ui.h:8
+msgid "Change from 1 to 2"
+msgstr "Canvi de 1 a 2"
+
+#: ../data/percentage.ui.h:9
+msgid "Value 2"
+msgstr "Valor 2"
+
+#: ../data/percentage.ui.h:10
+msgid "1 compared to 2"
+msgstr "1 comparat amb 2"
+
+#: ../data/percentage.ui.h:11
+msgid "Change from 2 to 1"
+msgstr "Canvi de 2 a 1"
+
+#: ../data/plot.ui.h:1
+msgid "Plot"
+msgstr "Dibuix"
+
+#: ../data/plot.ui.h:3 ../src/callbacks.cc:18933 ../src/callbacks.cc:29511
+#: ../src/callbacks.cc:34404
+msgid "_Save"
+msgstr "_Desa"
+
+#: ../data/plot.ui.h:4
+msgid "Save as png, svg, postscript, eps, latex or fig"
+msgstr "Desa com a png, svg, postscript, eps, latex o fig"
+
+#: ../data/plot.ui.h:10
+msgid "Vector/matrix"
+msgstr "Vector/matriu"
+
+#: ../data/plot.ui.h:11
+msgid "Paired matrix"
+msgstr "Matriu emparellada"
+
+#: ../data/plot.ui.h:13
+msgid "if you want to split matrix in rows instead of columns"
+msgstr "si voleu dividir la matriu en files en lloc de columnes"
+
+#: ../data/plot.ui.h:14
+msgid "X variable"
+msgstr "Variable X"
+
+#: ../data/plot.ui.h:15
+msgid "The variable name used in expression"
+msgstr "El nom de variable usat en l'expressió"
+
+#: ../data/plot.ui.h:16
+msgid "Style"
+msgstr "Estil"
+
+#: ../data/plot.ui.h:17
+msgid "Line"
+msgstr "Línia"
+
+#: ../data/plot.ui.h:18
+msgid "Points"
+msgstr "Punts"
+
+#: ../data/plot.ui.h:19
+msgid "Line with points"
+msgstr "Línia amb punts"
+
+#: ../data/plot.ui.h:20
+msgid "Boxes/bars"
+msgstr "Caixes/barres"
+
+#: ../data/plot.ui.h:21
+msgid "Histogram"
+msgstr "Histograma"
+
+#: ../data/plot.ui.h:22
+msgid "Steps"
+msgstr "Pasos"
+
+#: ../data/plot.ui.h:23
+msgid "Candlesticks"
+msgstr "Candelers"
+
+#: ../data/plot.ui.h:24
+msgid "Dots"
+msgstr "Cercles"
+
+#: ../data/plot.ui.h:25
+msgid "Smoothing"
+msgstr "Suavitzat"
+
+#: ../data/plot.ui.h:27
+msgid "Monotonic"
+msgstr "Monotònic"
+
+#: ../data/plot.ui.h:28
+msgid "Natural cubic splines"
+msgstr "Spline cúbic natural"
+
+#: ../data/plot.ui.h:29
+msgid "Bezier"
+msgstr "Bézier"
+
+#: ../data/plot.ui.h:30
+msgid "Bezier (monotonic)"
+msgstr "Bézier (monotònic)"
+
+#: ../data/plot.ui.h:31
+msgid "Y-axis"
+msgstr "Eix Y"
+
+#: ../data/plot.ui.h:32
+msgid "Primary"
+msgstr "Principal"
+
+#: ../data/plot.ui.h:33
+msgid "Secondary"
+msgstr "Secondari"
+
+#: ../data/plot.ui.h:36 ../data/shortcuts.ui.h:5
+msgid "_Remove"
+msgstr "_Elimina"
+
+#: ../data/plot.ui.h:37
+msgid "Data"
+msgstr "Dades"
+
+#: ../data/plot.ui.h:38
+msgid "Minimum x value"
+msgstr "Valor x mìnim"
+
+#: ../data/plot.ui.h:39
+msgid "Maximum x value"
+msgstr "Valor x màxim"
+
+#: ../data/plot.ui.h:40
+msgid "Sampling rate"
+msgstr "Taxa de mostreig"
+
+#: ../data/plot.ui.h:41
+msgid "Step size"
+msgstr "Mida de passos"
+
+#: ../data/plot.ui.h:42
+msgid "Function Range"
+msgstr "Rang de funció"
+
+#: ../data/plot.ui.h:43
+msgid "Display grid"
+msgstr "Mostra una graella"
+
+#: ../data/plot.ui.h:44
+msgid "Display full border"
+msgstr "Mostra la vora completa"
+
+#: ../data/plot.ui.h:45
+msgid "Minimum y value"
+msgstr "Valor y mínim"
+
+#: ../data/plot.ui.h:46
+msgid "Maximum y value"
+msgstr "Valor y màxim"
+
+#: ../data/plot.ui.h:47
+msgid "Logarithmic x scale"
+msgstr "Escala x logarítmica"
+
+#: ../data/plot.ui.h:48
+msgid "Logarithmic y scale"
+msgstr "Escala y logarítmica"
+
+#: ../data/plot.ui.h:49
+msgid "X-axis label"
+msgstr "Etiqueta de l'eix X"
+
+#: ../data/plot.ui.h:50
+msgid "Y-axis label"
+msgstr "Etiqueta de l'eix Y"
+
+#: ../data/plot.ui.h:51
+msgid "Line width"
+msgstr "Amplada de línia"
+
+#: ../data/plot.ui.h:52
+msgid "Color display"
+msgstr "Presentació acolorida"
+
+#: ../data/plot.ui.h:53
+msgid "Color"
+msgstr "Color"
+
+#: ../data/plot.ui.h:54
+msgid "Monochrome"
+msgstr "Monocrom"
+
+#: ../data/plot.ui.h:55
+msgid "Legend placement"
+msgstr "Posició de la llegenda"
+
+#: ../data/plot.ui.h:56
+msgid "Top-left"
+msgstr "Superior-esquerra"
+
+#: ../data/plot.ui.h:57
+msgid "Top-right"
+msgstr "Superior-dreta"
+
+#: ../data/plot.ui.h:58
+msgid "Bottom-left"
+msgstr "Inferior-esquerra"
+
+#: ../data/plot.ui.h:59
+msgid "Bottom-right"
+msgstr "Inferior-dreta"
+
+#: ../data/plot.ui.h:60
+msgid "Below"
+msgstr "A baix"
+
+#: ../data/plot.ui.h:61
+msgid "Outside"
+msgstr "A fora"
+
+#: ../data/plot.ui.h:62
+msgid "Appearance"
+msgstr "Aparència"
+
+#: ../data/precision.ui.h:1
+msgid "Precision"
+msgstr "Precisió"
+
+#: ../data/precision.ui.h:4
+msgid "_Recalculate"
+msgstr "_Recalcula"
+
+#: ../data/precision.ui.h:5
+msgid "Recalculate expression"
+msgstr "Recalcula l'expressió"
+
+#: ../data/precision.ui.h:6
+msgid ""
+"The number of significant digits to display/calculate (simple arithmetics "
+"are always calculated exact)"
+msgstr ""
+"El nombre de xifres significats a mostrar/calcular (l'aritmètica senzilla "
+"sempre es calcula amb exactitud)"
+
+#: ../data/preferences.ui.h:1
+msgid "Preferences"
+msgstr "Preferències"
+
+#: ../data/preferences.ui.h:3
+msgid "Save mode on exit"
+msgstr "Desa el mode en surtir"
+
+#: ../data/preferences.ui.h:4
+msgid "If the mode of the calculator shall be restored"
+msgstr "Si el mode del calculador es restaurarà"
+
+#: ../data/preferences.ui.h:5
+msgid "Save definitions on exit"
+msgstr "Desa les definicions en surtir"
+
+#: ../data/preferences.ui.h:6
+msgid ""
+"If changes to functions, units and variables shall be saved automatically"
+msgstr ""
+"Si els canvis a les funcions, unitats i variables es desaran automàticament"
+
+#: ../data/preferences.ui.h:7
+msgid "Clear history on exit"
+msgstr "Neteja l'historial en surtir"
+
+#: ../data/preferences.ui.h:8
+msgid "Allow multiple instances"
+msgstr "Permet múltiples instàncies"
+
+#: ../data/preferences.ui.h:9
+msgid ""
+"Allow multiple instances of the Qalculate! main window to be open at the "
+"same time.\n"
+"\n"
+"Note that only the mode, history and definitions of the last closed instance "
+"will be saved."
+msgstr ""
+"Permet que s'obrin múltiples instàncies de la finestra principal a la "
+"vegada. \n"
+"\n"
+"Tingueu en compte que només es desaran el mode, l'historial i les "
+"definicions de la última instància tancada."
+
+#: ../data/preferences.ui.h:12
+msgid "Notify when a new version is available"
+msgstr "Notifica quan una versió nova estigui disponible"
+
+#: ../data/preferences.ui.h:13
+msgid "Use keyboard keys for RPN"
+msgstr "Usa les tecles del teclat per a la NPI"
+
+#: ../data/preferences.ui.h:14
+msgid "Use keyboard operator keys for RPN operations (+-*/^)."
+msgstr "Usa les tecles d'operador del teclat per a les operacions NPI (+-*/^)."
+
+#: ../data/preferences.ui.h:15
+msgid "Use caret for bitwise XOR"
+msgstr "Usa el caret per XOR bit a bit"
+
+#: ../data/preferences.ui.h:16
+msgid ""
+"Input XOR (⊻) using caret (^) on keyboard (otherwise use Ctrl+^). The "
+"exponentiation operator (^) can always be input using Ctrl+*."
+msgstr ""
+"Introdueix el XOR (⊻) mitjançant el caret (^) en el teclat (d'altra manera, "
+"usa Ctrl+^). Sempre es pot introduir l'operador d'exponenciació (^) "
+"mitjançant Ctrl+*."
+
+#: ../data/preferences.ui.h:17
+msgid "Add calculate-as-you-type result to history"
+msgstr "Afegeix, mentre teclegeu, el resultat del càlcul a l'historial"
+
+#: ../data/preferences.ui.h:18
+msgid "Delay:"
+msgstr "Retard:"
+
+#: ../data/preferences.ui.h:19
+msgid "Time limit for plot:"
+msgstr "Limit de temps del dibuix:"
+
+#: ../data/preferences.ui.h:20
+msgid "Behavior"
+msgstr "Comportament"
+
+#: ../data/preferences.ui.h:21
+msgid "Enable Unicode symbols"
+msgstr "Habilita els símbols d'Unicode"
+
+#: ../data/preferences.ui.h:22
+msgid "Disable this if you have problems with some fancy characters"
+msgstr "Deshabilita això si teniu problemes amb alguns caràcters sofisticats"
+
+#: ../data/preferences.ui.h:23
+msgid "Ignore system language (requires restart)"
+msgstr "Ignora la llengua del sistema (requereix reinici)"
+
+#: ../data/preferences.ui.h:24
+msgid "Use system tray icon"
+msgstr "Usa una icona en la safata del sistema"
+
+#: ../data/preferences.ui.h:25
+msgid "Hides the application in the system tray when the main window is closed"
+msgstr ""
+"Amaga l'aplicació en la safata del sistema quan es tanca la finestra "
+"principal"
+
+#: ../data/preferences.ui.h:26
+msgid "Hide on startup"
+msgstr "Amaga en iniciar"
+
+#: ../data/preferences.ui.h:27
+msgid "Remember window position"
+msgstr "Recorda la posició de la finestra"
+
+#: ../data/preferences.ui.h:28
+msgid "Keep above other windows"
+msgstr "Manté superior a les altres finestres"
+
+#: ../data/preferences.ui.h:29
+msgid ""
+"Keep the main window above other windows (depending on platform and settings "
+"this might not work)"
+msgstr ""
+"Manté la finestra principal superior a les altres finestres (depenent del "
+"plataforma i de la configuració del sistema, potser no funciona)"
+
+#: ../data/preferences.ui.h:30
+msgid "Application name"
+msgstr "Nom d'aplicació"
+
+#: ../data/preferences.ui.h:31
+msgid "Result"
+msgstr "Resultat"
+
+#: ../data/preferences.ui.h:32
+msgid "Application name + result"
+msgstr "Nom d'aplicació + resultat"
+
+#: ../data/preferences.ui.h:33 ../src/callbacks.cc:18996
+msgid "Mode"
+msgstr "Mode"
+
+#: ../data/preferences.ui.h:34
+msgid "Application name + mode"
+msgstr "Nom d'aplicació + mode"
+
+#: ../data/preferences.ui.h:35
+msgid "Window title"
+msgstr "Títol de finestra"
+
+#: ../data/preferences.ui.h:36 ../src/callbacks.cc:16890
+#: ../src/callbacks.cc:18169 ../src/callbacks.cc:19161
+#: ../src/callbacks.cc:34130
+msgid "Default"
+msgstr "Predeterminat"
+
+#: ../data/preferences.ui.h:37
+msgid "Light"
+msgstr "Clar"
+
+#: ../data/preferences.ui.h:38
+msgid "Dark"
+msgstr "Fosc"
+
+#: ../data/preferences.ui.h:39
+msgid "High contrast"
+msgstr "Contrast alt"
+
+#: ../data/preferences.ui.h:40
+msgid "Dark high contrast"
+msgstr "Contrast alt fosc"
+
+#: ../data/preferences.ui.h:41
+msgid "Theme"
+msgstr "Tema"
+
+#: ../data/preferences.ui.h:42
+msgid "Button padding"
+msgstr "Espaiat de botó"
+
+#: ../data/preferences.ui.h:43
+msgid "/"
+msgstr "/"
+
+#: ../data/preferences.ui.h:44
+msgid "Number of expression lines"
+msgstr "Nombre de línies d'expressió"
+
+#: ../data/preferences.ui.h:45
+msgid "3"
+msgstr "3"
+
+#: ../data/preferences.ui.h:46
+msgid "Display expression status"
+msgstr "Mostra l'estat de l'expressió"
+
+#: ../data/preferences.ui.h:47
+msgid ""
+"If as-you-type expression status shall be displayed below the expression "
+"entry"
+msgstr ""
+"Si, mentre teclegeu, l'estat d'expressió es mostrarà abaix de l'entrada "
+"d'expressió"
+
+#: ../data/preferences.ui.h:48
+msgid "Persistent keypad"
+msgstr "Teclat numèric persistent"
+
+#: ../data/preferences.ui.h:49
+msgid "Look & Feel"
+msgstr "Aparença"
+
+#: ../data/preferences.ui.h:50
+msgid "Binary two's complement representation"
+msgstr "Representació binaria de complement a dos"
+
+#: ../data/preferences.ui.h:51
+msgid ""
+"If two's complement representation shall be used for negative binary numbers."
+msgstr ""
+"Si la representació de complement a dos s'usarà pels nombres binaris "
+"negatius."
+
+#: ../data/preferences.ui.h:52
+msgid "Hexadecimal two's complement representation"
+msgstr "Representació hexadecimal de complement a dos"
+
+#: ../data/preferences.ui.h:53
+msgid ""
+"If two's complement representation shall be used for negative hexadecimal "
+"numbers."
+msgstr ""
+"Si la representació de complement a dos s'usarà pels nombres hexadecimals "
+"negatius."
+
+#: ../data/preferences.ui.h:54
+msgid "Use lower case letters in non-decimal numbers"
+msgstr "Usa lletres minúscules en nombres no decimals"
+
+#: ../data/preferences.ui.h:55
+msgid "If lower case letters should be used in numbers with non-decimal base"
+msgstr "Si es deuen usar lletres minúscules en els nombres amb base no decimal"
+
+#: ../data/preferences.ui.h:56
+msgid "Alternative base prefixes"
+msgstr "Prefixes de base alternatius"
+
+#: ../data/preferences.ui.h:57
+msgid ""
+"If hexadecimal numbers shall be displayed with \"0x0\" and binary numbers "
+"with \"0b00\" as prefixes"
+msgstr ""
+"Si es mostraran els nombres hexadecimals amb \"0x0\" i els nombres binaris "
+"amb \"0b00\" com a prefixes"
+
+#: ../data/preferences.ui.h:58
+msgid "Spell out logical operators"
+msgstr "Enuncia els operadors lògics"
+
+#: ../data/preferences.ui.h:59
+msgid "If logical and/or shall be displayed as \"&&\"/\"||\" or \"and\"/\"or\""
+msgstr "Si i/o lògics es mostraran com a \"&&\"/\"||\" o \"and\"/\"or\""
+
+#: ../data/preferences.ui.h:60
+msgid "If \"e\" shall be used instead of \"E\" in numbers"
+msgstr "Si s'usarà \"e\" en lloc de \"E\" en nombres"
+
+#: ../data/preferences.ui.h:61
+msgid "Use E-notation instead of 10<sup><i>n</i></sup>"
+msgstr "Usa la notació E en lloc de 10<sup><i>n</i></sup>"
+
+#: ../data/preferences.ui.h:62
+msgid "Use lower case \"e\" (as in 1e10)"
+msgstr "Usa \"e\" minúscula (tal com 1e10)"
+
+#: ../data/preferences.ui.h:63
+msgid "Use 'j' as imaginary unit"
+msgstr "Usa 'j' com a unitat imaginària"
+
+#: ../data/preferences.ui.h:64
+msgid ""
+"Use 'j' (instead of 'i') as default symbol for the imaginary unit, and place "
+"it in front of the imaginary part."
+msgstr ""
+"Usa 'j' (en lloc de 'i') com al símbol predeterminat pela unitat imaginària, "
+"i col·loca'l davant la part imaginària."
+
+#: ../data/preferences.ui.h:65
+msgid "Use comma as decimal separator"
+msgstr "Usa la coma com a separador decimal"
+
+#: ../data/preferences.ui.h:66
+msgid ""
+"Allow dots, '.',  to be used as thousands separator instead of as an "
+"alternative decimal sign"
+msgstr ""
+"Permet que els punts, '.', s'usin com a separador de millars en lloc d'un "
+"signe decimal alternatiu"
+
+#: ../data/preferences.ui.h:67
+msgid "Ignore comma in numbers"
+msgstr "Ignora comas en els nombres"
+
+#: ../data/preferences.ui.h:68
+msgid ""
+"Allow commas, ',', to be used as thousands separator instead of as an "
+"function argument separator"
+msgstr ""
+"Permet que les comes, ',', s'usin com a separador de millars en lloc de ser "
+"un separador dels arguments d'una funció"
+
+#: ../data/preferences.ui.h:69
+msgid "Ignore dots in numbers"
+msgstr "Ignora els punts en els nombres"
+
+#: ../data/preferences.ui.h:70
+msgid ""
+"Allow dots, '.', to be used as thousands separator instead of as an "
+"alternative decimal sign"
+msgstr ""
+"Permet que els punts, '.', s'usin com a separador de millars en lloc d'un "
+"signe decimal alternatiu"
+
+#: ../data/preferences.ui.h:71
+msgid "Digit grouping"
+msgstr "Agrupament de xifres"
+
+#: ../data/preferences.ui.h:72
+msgid "off"
+msgstr "desactivat"
+
+#: ../data/preferences.ui.h:73
+msgid "standard"
+msgstr "estàndar"
+
+#: ../data/preferences.ui.h:74
+msgid "local"
+msgstr "local"
+
+#: ../data/preferences.ui.h:75
+msgid "Multiplication sign"
+msgstr "Signe de multiplicació"
+
+#: ../data/preferences.ui.h:76
+msgid "Division sign"
+msgstr "Signe de divisó"
+
+#: ../data/preferences.ui.h:77
+msgid "Copy digit separator"
+msgstr "Copia els separadors de xifres"
+
+#: ../data/preferences.ui.h:78
+msgid "Deactivate to remove digit separator when copying result"
+msgstr ""
+"Desactiva per a eliminar els separadors de xifres quan es copia el resultat"
+
+#: ../data/preferences.ui.h:79
+msgid "Numbers & Operators"
+msgstr "Nombres i operadors"
+
+#: ../data/preferences.ui.h:80
+msgid "Use binary prefixes for information units"
+msgstr "Una els prefixes binaris per a les unitats d'informació"
+
+#: ../data/preferences.ui.h:81
+msgid ""
+"Use binary, instead of decimal, prefixes by default for information units (e."
+"g. bytes)."
+msgstr ""
+"Usa els prefixes binaris, en lloc dels decimals, per defecte per a les "
+"unitats d'informació (e.g. bytes)."
+
+#: ../data/preferences.ui.h:82
+msgid "Conversion to local currency"
+msgstr "Conversió a la moneda local"
+
+#: ../data/preferences.ui.h:83
+msgid ""
+"Automatically convert to the local currency when optimal unit conversion is "
+"activated."
+msgstr ""
+"Converteix a la moneda local automàticament quan la conversió d'unitat "
+"òptima està activada."
+
+#: ../data/preferences.ui.h:84
+msgid "Update exchange rates on start"
+msgstr "Actualitza les taxes d'intercanvi en iniciar"
+
+#: ../data/preferences.ui.h:85
+msgid ""
+"If current exchange rates shall be downloaded from the internet at program "
+"start"
+msgstr ""
+"Si les taxes d'intercanvi actuals es descarregaran de l'Internet a l'inici "
+"del programa"
+
+#: ../data/preferences.ui.h:86
+msgid "Exchange rates updates"
+msgstr "Actualitzacions de taxes d'intercanvi"
+
+#: ../data/preferences.ui.h:87
+msgid "Temperature calculation mode:"
+msgstr "Mode de càlcul de temperatura:"
+
+#: ../data/preferences.ui.h:88 ../src/callbacks.cc:2698
+msgid "Absolute"
+msgstr "Absolut"
+
+#: ../data/preferences.ui.h:89 ../src/callbacks.cc:2705
+msgid "Relative"
+msgstr "Relatiu"
+
+#: ../data/preferences.ui.h:90 ../src/callbacks.cc:2712
+msgid "Hybrid"
+msgstr "Híbrid"
+
+#: ../data/preferences.ui.h:91
+msgid "Units & Currencies"
+msgstr "Unitats i monedes"
+
+#: ../data/preferences.ui.h:92
+msgid "Show expression completion suggestions"
+msgstr "Mostra els suggeriments de compleció d'expressió"
+
+#: ../data/preferences.ui.h:93
+msgid "Search titles and countries"
+msgstr "Cerca en els títols i països"
+
+#: ../data/preferences.ui.h:94
+msgid "Minimum characters"
+msgstr "Caràcters mínims"
+
+#: ../data/preferences.ui.h:95
+msgid "Popup delay (ms)"
+msgstr "Retard de caixa emergent (ms)"
+
+#: ../data/preferences.ui.h:96
+msgid "Completion"
+msgstr "Compleció"
+
+#: ../data/preferences.ui.h:97
+msgid "Status warning color"
+msgstr "Color d'estat d'advertència"
+
+#: ../data/preferences.ui.h:98
+msgid "Status error color"
+msgstr "Color d'estat d'error"
+
+#: ../data/preferences.ui.h:99
+msgid "Custom status font"
+msgstr "Tipus de lletra personalitzat per a l'estat"
+
+#: ../data/preferences.ui.h:100
+msgid ""
+"If you want to use a font other than the default in the status display below "
+"the expression entry"
+msgstr ""
+"Si voleu usar altre tipus de lletra que el predeterminat en la presentació "
+"de l'estat abaix de l'entrada d'expressió"
+
+#: ../data/preferences.ui.h:101
+msgid "Custom expression font"
+msgstr "Tipus de lletra personalitzat per a l'expressió"
+
+#: ../data/preferences.ui.h:102
+msgid ""
+"If you want to use a font other than the default in the expression entry"
+msgstr ""
+"Si voleu usar altre tipus de lletra que el predeterminat en l'entrada "
+"d'expressió"
+
+#: ../data/preferences.ui.h:103
+msgid "Custom result font"
+msgstr "Tipus de lletra personalitzat per al resultat"
+
+#: ../data/preferences.ui.h:104
+msgid "If you want to use a font other than the default in the result display"
+msgstr ""
+"Si voleu usar altre tipus de lletra que el predeterminat en la presentació "
+"del resultat"
+
+#: ../data/preferences.ui.h:105
+msgid "Custom keypad font"
+msgstr "Tipus de lletra personalitzat per al teclat numèric"
+
+#: ../data/preferences.ui.h:106
+msgid "If you want to use a font other than the default in the keypad"
+msgstr ""
+"Si voleu usar altre tipus de lletra que el predeterminat en el teclat numèric"
+
+#: ../data/preferences.ui.h:107
+msgid "Custom application font"
+msgstr "Tipus de lletra personalitzat per a l'aplicació"
+
+#: ../data/preferences.ui.h:108
+msgid ""
+"If you want to use a font other than the default for the whole application"
+msgstr ""
+"Si voleu usar altre tipus de lletra que el predeterminat per a l'aplicació "
+"sencera"
+
+#: ../data/preferences.ui.h:109
+msgid "Text color"
+msgstr "Color de text"
+
+#: ../data/preferences.ui.h:110
+msgid "Fonts & Colors"
+msgstr "Tipus de lletra i colors"
+
+#: ../data/setbase.ui.h:11
+msgid "Other:"
+msgstr "Altra:"
+
+#: ../data/setbase.ui.h:12 ../src/interface.cc:3296 ../src/interface.cc:3373
+#: ../src/callbacks.cc:7229 ../src/callbacks.cc:28139 ../src/callbacks.cc:28279
+#: ../src/callbacks.cc:28414 ../src/callbacks.cc:28421
+#: ../src/callbacks.cc:28501 ../src/callbacks.cc:28586
+#: ../src/callbacks.cc:28625 ../src/callbacks.cc:28633
+msgid "Bijective base-26"
+msgstr "Base 26 bijectiva"
+
+#: ../data/setbase.ui.h:13
+msgid "<b>Result Base</b>"
+msgstr "<b>Base del resultat</b>"
+
+#: ../data/setbase.ui.h:14
+msgid "<b>Expression Base</b>"
+msgstr "<b>Base de l'expressió</b>"
+
+#: ../data/shortcuts.ui.h:6
+msgid "New Keyboard Shortcut"
+msgstr "Drecera de teclat nova"
+
+#: ../data/simplefunctionedit.ui.h:1 ../data/variableedit.ui.h:1
+#: ../src/callbacks.cc:16213
+msgid "Edit Variable"
+msgstr "Edita la variable"
+
+#: ../data/simplefunctionedit.ui.h:2
+msgid "Advanced"
+msgstr "Avançat"
+
+#: ../data/simplefunctionedit.ui.h:4 ../data/variableedit.ui.h:4
+msgid "Accept the creation/modification of this variable"
+msgstr "Accepta la creació/modificació d'aquesta variable"
+
+#: ../data/simplefunctionedit.ui.h:9
+msgid "x, y, z"
+msgstr "x, y, z"
+
+#: ../data/simplefunctionedit.ui.h:10
+msgid "Use x, y and z for 1st, 2nd and 3rd function argument, respectively."
+msgstr ""
+"Usa x, y i z pel primer, segon i tercer argument de funció, respectivament."
+
+#: ../data/simplefunctionedit.ui.h:11
+msgid "\\x, \\y, \\z"
+msgstr "\\x, \\y, \\z"
+
+#: ../data/simplefunctionedit.ui.h:12
+msgid ""
+"Use \\x, \\y and \\z for 1st, 2nd and 3rd function argument, respectively. "
+"This avoids potential conflicts with variables, functions and units."
+msgstr ""
+"Usa \\x, \\y i \\z pel primer, segon i tercer argument de funció, "
+"respectivament. Això evita conflictes potencials amb variables, funcions i "
+"unitats."
+
+#: ../data/unitedit.ui.h:1 ../src/callbacks.cc:15199
+msgid "Edit Unit"
+msgstr "Edita la unitat"
+
+#: ../data/unitedit.ui.h:4
+msgid "Do not create/modify this unit"
+msgstr "No creis/modifiquis aquesta unitat"
+
+#: ../data/unitedit.ui.h:6
+msgid "Accept the creation/modification of this unit"
+msgstr "Accepta la creació/modificació d'aquesta unitat"
+
+#: ../data/unitedit.ui.h:8
+msgid "Singular form of this unit's name"
+msgstr "Forma singular del nom d'aquesta unitat"
+
+#: ../data/unitedit.ui.h:12
+msgid "Title displayed in menus and in unit manager"
+msgstr "Títol mostrat en els menús i en el gestor d'unitats"
+
+#: ../data/unitedit.ui.h:13
+msgid "System"
+msgstr "Sistema"
+
+#: ../data/unitedit.ui.h:14
+msgid "Imperial"
+msgstr "Imperial"
+
+#: ../data/unitedit.ui.h:15
+msgid "US Survey"
+msgstr "Agrimensura estatunidenca"
+
+#: ../data/unitedit.ui.h:16
+msgid "Hide unit"
+msgstr "Amaga la unitat"
+
+#: ../data/unitedit.ui.h:17
+msgid "If this unit shall be hidden in menus"
+msgstr "Si s'amagarà aquesta unitat en els menús"
+
+#: ../data/unitedit.ui.h:21
+msgid "Class"
+msgstr "Classe"
+
+#: ../data/unitedit.ui.h:22
+msgid ""
+"The class that this unit belongs to. Named derived units are defined in "
+"relation to a single other unit, with an optional exponent, while (unnamed) "
+"derived units are defined by a unit expression with one or multiple units."
+msgstr ""
+"La classe a la qual pertany aquesta unitat. Es defineixen les unitats "
+"derivades anomenades en relació a una sola altra unitat, amb un exponent "
+"opcional, mentre es defineixen les unitats derivades (sense nom) per una "
+"expressió d'unitat amb una unitat o múltiples unitats."
+
+#: ../data/unitedit.ui.h:23
+msgid "Base unit"
+msgstr "Unitat base"
+
+#: ../data/unitedit.ui.h:24
+msgid "Named derived unit"
+msgstr "Unitat derivada anomenada"
+
+#: ../data/unitedit.ui.h:25
+msgid "Derived unit"
+msgstr "Unitat derivada"
+
+#: ../data/unitedit.ui.h:26
+msgid "Base unit(s)"
+msgstr "Unitat(s) base(s)"
+
+#: ../data/unitedit.ui.h:27
+msgid ""
+"Unit (for named derived unit) or unit expression (for unnamed derived unit) "
+"that this unit is defined in relation to"
+msgstr ""
+"Unitat (per a una unitat derivada amb nom) o expressió d'unitat (per a una "
+"unitat derivada sense nom) a la qual aquesta unitat està definida"
+
+#: ../data/unitedit.ui.h:28
+msgid "Exponent"
+msgstr "Exponent"
+
+#: ../data/unitedit.ui.h:29
+msgid "Exponent of the base unit"
+msgstr "Exponent de la unitat base"
+
+#: ../data/unitedit.ui.h:30
+msgid "Relation"
+msgstr "Relació"
+
+#: ../data/unitedit.ui.h:31
+msgid ""
+"Relation to the base unit. For linear relations this should just be a "
+"number.\n"
+"\n"
+"For non-linear relations use \\x for the factor and \\y for the exponent (e."
+"g. \"\\x + 273.15\" for the relation between degrees Celsius and Kelvin)."
+msgstr ""
+"Relació a la unitat base. Per als relacions linears això només deu ser un "
+"nombre.\n"
+"\n"
+"Per a les relacions no linears useu \\x pel factor i \\y pel exponent (per "
+"exemple \"\\x + 273.15\" pela relació entre graus Celsius i Kelvin)."
+
+#: ../data/unitedit.ui.h:34
+msgid "Relation is exact"
+msgstr "La relació és exacta"
+
+#: ../data/unitedit.ui.h:35
+msgid "If the relation is precise"
+msgstr "Si la relació és precisa"
+
+#: ../data/unitedit.ui.h:36
+msgid "Inverse relation"
+msgstr "Relació inversa"
+
+#: ../data/unitedit.ui.h:37
+msgid "Specify for non-linear relation, for conversion back to the base unit."
+msgstr ""
+"Especifiqueu per a relació no linear, per a conversió de retorn a la unitat "
+"base."
+
+#: ../data/unitedit.ui.h:38
+msgid "Mix with base unit"
+msgstr "Mescla amb la unitat base"
+
+#: ../data/unitedit.ui.h:39
+msgid ""
+"- Decides which units the base unit is mixed with if multple options exist.\n"
+"- The original unit will not be mixed with units with lower priority.\n"
+"- A lower value means higher priority."
+msgstr ""
+"- Decideix amb quines unitats es mescla la unitat base si existeixen "
+"múltiples opcions.\n"
+"- No es mesclarà la unitat original amb unitats de prioritat més baixa.\n"
+"- Un valor inferior vol dir prioritat superior."
+
+#: ../data/unitedit.ui.h:42
+msgid "Priority"
+msgstr "Prioritat"
+
+#: ../data/unitedit.ui.h:43
+msgid "Minimum base unit number"
+msgstr "Nombre d'unitat base mínim"
+
+#: ../data/unitedit.ui.h:44
+msgid "Use with prefixes by default"
+msgstr "Usa amb prefixes per defecte"
+
+#: ../data/units.ui.h:4
+msgid "Create a new unit"
+msgstr "Crea una unitat nova"
+
+#: ../data/units.ui.h:6
+msgid "Edit the selected unit"
+msgstr "Edita la unitat seleccionada"
+
+#: ../data/units.ui.h:8
+msgid "Insert the selected unit into the expression entry"
+msgstr "Insereix la unitat seleccionada en l'entrada d'expressió"
+
+#: ../data/units.ui.h:9
+msgid "C_onvert"
+msgstr "C_onverteix"
+
+#: ../data/units.ui.h:10
+msgid "Convert the result to the selected unit"
+msgstr "Converteix el resultat a la unitat seleccionada"
+
+#: ../data/units.ui.h:12
+msgid "Delete the selected unit"
+msgstr "Suprimeix la unitat seleccionada"
+
+#: ../data/units.ui.h:13
+msgid "(De)activate the selected unit"
+msgstr "(Des)activa la unitat seleccionada"
+
+#: ../data/units.ui.h:16
+msgid "_Unit"
+msgstr "_Unitat"
+
+#: ../data/units.ui.h:17
+msgid "Convert between units"
+msgstr "Converteix entre unitats"
+
+#: ../data/units.ui.h:18
+msgid "="
+msgstr "="
+
+#: ../data/units.ui.h:19
+msgid "Conver_sion"
+msgstr "Conver_sió"
+
+#: ../data/units.ui.h:20
+msgid "Converted value"
+msgstr "Valor convertit"
+
+#: ../data/units.ui.h:21
+msgid "Value to convert from"
+msgstr "Valor del qual convertir"
+
+#: ../data/units.ui.h:22
+msgid "Type anywhere"
+msgstr "Teclegeu en qualsevol lloc"
+
+#: ../data/unknownedit.ui.h:1 ../src/callbacks.cc:16029
+msgid "Edit Unknown Variable"
+msgstr "Edició de variable desconeguda"
+
+#: ../data/unknownedit.ui.h:4
+msgid "Do not create/modify this unknown variable"
+msgstr "No creis/modifiques aquesta variable desconeguda"
+
+#: ../data/unknownedit.ui.h:6
+msgid "Accept the creation/modification of this unknown variable"
+msgstr "Accepta la creació/modificació d'aquesta variable desconeguda"
+
+#: ../data/unknownedit.ui.h:8
+msgid "Name used to reference this unknown variable in expressions"
+msgstr ""
+"El nom usat per a referir a aquesta variable desconeguda en les expressions"
+
+#: ../data/unknownedit.ui.h:10
+msgid "Use custom assumptions"
+msgstr "Usa suposicions personalitzades"
+
+#: ../data/unknownedit.ui.h:11 ../src/interface.cc:2843
+#: ../src/interface.cc:3104
+msgid "Type"
+msgstr "Tipus"
+
+#: ../data/unknownedit.ui.h:13
+msgid "Real Number"
+msgstr "Nombre real"
+
+#: ../data/unknownedit.ui.h:14
+msgid "Rational Number"
+msgstr "Nombre racional"
+
+#: ../data/unknownedit.ui.h:17
+msgid "Sign"
+msgstr "Signe"
+
+#: ../data/unknownedit.ui.h:25
+msgid "The category this unknown variable belongs to"
+msgstr "La categoria a la qual pertany aquesta variable desconeguda"
+
+#: ../data/variableedit.ui.h:10
+msgid "Value of this variable (expression)"
+msgstr "Valor d'aquesta variable (expressió)"
+
+#: ../data/variableedit.ui.h:11
+msgid "value is exact"
+msgstr "el valor és exacte"
+
+#: ../data/variableedit.ui.h:12
+msgid "If the value is precise"
+msgstr "Si el valor es precise"
+
+#: ../data/variableedit.ui.h:13
+msgid "The category this variable belongs to"
+msgstr "La categoria a la qual pertany aquesta variable"
+
+#: ../data/variables.ui.h:4
+msgid "Create a new variable"
+msgstr "Crea una variable nova"
+
+#: ../data/variables.ui.h:6
+msgid "Edit the selected variable"
+msgstr "Edita la variable seleccionada"
+
+#: ../data/variables.ui.h:8
+msgid "Insert the selected variable into the expression entry"
+msgstr "Insereix la variable seleccionada a l'entrada d'expressió"
+
+#: ../data/variables.ui.h:10
+msgid "Delete the selected variable"
+msgstr "Elimina la variable seleccionada"
+
+#: ../data/variables.ui.h:11
+msgid "(De)activate the selected variable"
+msgstr "(Des)activa la variable seleccionada"
+
+#: ../data/variables.ui.h:13
+msgid "E_xport"
+msgstr "E_xporta"
+
+#: ../data/variables.ui.h:15
+msgid "_Variable"
+msgstr "_Variable"
+
+#: ../src/main.cc:88
+msgid "Execute expressions and commands from a file"
+msgstr "Executa expressions i ordres d'un fitxer"
+
+#: ../src/main.cc:89
+msgid "Start a new instance of the application"
+msgstr "Inicia una instància nova de l'aplicació"
+
+#: ../src/main.cc:90
+msgid "Display the application version"
+msgstr "Mostra la versió de l'aplicació"
+
+#: ../src/main.cc:91
+msgid "Specify the window title"
+msgstr "Especifica el títol de finestra"
+
+#: ../src/main.cc:91
+msgid "TITLE"
+msgstr "TÍTOL"
+
+#: ../src/main.cc:92
+msgid "Expression to calculate"
+msgstr "Expressió a calcular"
+
+#: ../src/main.cc:92
+msgid "[EXPRESSION]"
+msgstr "[EXPRESSIÓ]"
+
+#: ../src/main.cc:215 ../src/callbacks.cc:33079
+msgid ""
+"Type a mathematical expression above, e.g. \"5 + 2 / 3\",\n"
+"and press the enter key."
+msgstr ""
+"Teclegeu una expressió matemàtica a dalt, per exemple \"5 + 2 / 3\",\n"
+"i premeu el teclat Retorn."
+
+#: ../src/main.cc:238
+msgid "ans"
+msgstr "res"
+
+#: ../src/main.cc:239
+msgid "Last Answer"
+msgstr "Última resposta"
+
+#: ../src/main.cc:240 ../src/callbacks.cc:467 ../src/callbacks.cc:468
+msgid "answer"
+msgstr "resposta"
+
+#: ../src/main.cc:242
+msgid "Answer 2"
+msgstr "Resposta 2"
+
+#: ../src/main.cc:243
+msgid "Answer 3"
+msgstr "Resposta 3"
+
+#: ../src/main.cc:244
+msgid "Answer 4"
+msgstr "Resposta 4"
+
+#: ../src/main.cc:245
+msgid "Answer 5"
+msgstr "Resposta 5"
+
+#: ../src/main.cc:255
+msgid "Memory"
+msgstr "Memòria"
+
+#: ../src/main.cc:267 ../src/searchprovider.cc:652
+#, c-format
+msgid "Failed to load global definitions!\n"
+msgstr "S'ha fallat en carregar les definicions globals!\n"
+
+#. if no category has been selected (previously selected has been renamed/deleted), select "All"
+#: ../src/main.cc:287 ../src/main.cc:290 ../src/main.cc:293
+#: ../src/callbacks.cc:4354 ../src/callbacks.cc:4415 ../src/callbacks.cc:4454
+#: ../src/callbacks.cc:4715 ../src/callbacks.cc:4778 ../src/callbacks.cc:4880
+#: ../src/callbacks.cc:4975 ../src/callbacks.cc:5035 ../src/callbacks.cc:5121
+#: ../src/callbacks.cc:5220 ../src/callbacks.cc:5275 ../src/callbacks.cc:5525
+msgid "All"
+msgstr "Tot"
+
+#: ../src/main.cc:514
+#, c-format
+msgid ""
+"By default, only one instance (one main window) of %s is allowed.\n"
+"\n"
+"If multiple instances are opened simultaneously, only the definitions "
+"(variables, functions, etc.), mode, preferences, and history of the last "
+"closed window will be saved.\n"
+"\n"
+"Do you, despite this, want to change the default behavior and allow multiple "
+"simultaneous instances?"
+msgstr ""
+"Per defecte, es permet només una instància (una finestra principal) de %s.\n"
+"\n"
+"Si s'obren múltiples instàncies simultàniament, només es desaran les "
+"definicions (variables, funcions etc.), el mode, les preferències i "
+"l'historial de la última finestra tancada\n"
+"\n"
+"Voleu, malgrat això, canviar el comportament predeterminat i permetre "
+"múltiples instàncies simultànies?"
+
+#: ../src/interface.cc:963
+#, c-format
+msgid "Right-click/long press: %s"
+msgstr "Clic dret o premuda llarga: %s"
+
+#: ../src/interface.cc:964
+#, c-format
+msgid "Right-click: %s"
+msgstr "Clic dret: %s"
+
+#: ../src/interface.cc:970
+#, c-format
+msgid "Middle-click: %s"
+msgstr "Clic del mig: %s"
+
+#: ../src/interface.cc:1023 ../src/interface.cc:3993
+msgid "Cycle through previous expression"
+msgstr "Mou per les expressions prèvies"
+
+#: ../src/interface.cc:1029 ../src/interface.cc:3994
+msgid "Move cursor left or right"
+msgstr "Mou el cursor a l'esquerra o a la dreta"
+
+#: ../src/interface.cc:1029 ../src/interface.cc:3994
+msgid "Move cursor to beginning or end"
+msgstr "Mou el cursor al principi o al fin"
+
+#: ../src/interface.cc:1032 ../src/interface.cc:3996
+msgid "Uncertainty/interval"
+msgstr "Incertesa/interval"
+
+#: ../src/interface.cc:1032 ../src/interface.cc:3996
+msgid "Relative error"
+msgstr "Error relatiu"
+
+#: ../src/interface.cc:1033 ../src/interface.cc:3997
+msgid "Argument separator"
+msgstr "Separador d'arguments"
+
+#: ../src/interface.cc:1033 ../src/interface.cc:1048 ../src/interface.cc:3997
+#: ../src/interface.cc:4011
+msgid "Blank space"
+msgstr "Espai en blanc"
+
+#: ../src/interface.cc:1033 ../src/interface.cc:1048 ../src/interface.cc:3997
+#: ../src/interface.cc:4011
+msgid "New line"
+msgstr "Línia nova"
+
+#: ../src/interface.cc:1034 ../src/interface.cc:3998
+msgid "Smart parentheses"
+msgstr "Parèntesis intel·ligents"
+
+#: ../src/interface.cc:1034 ../src/interface.cc:3998
+msgid "Vector brackets"
+msgstr "Claudàtors de vector"
+
+#: ../src/interface.cc:1036 ../src/interface.cc:3999
+msgid "Left parenthesis"
+msgstr "Parèntesi esquerre"
+
+#: ../src/interface.cc:1036 ../src/interface.cc:3999
+msgid "Left vector bracket"
+msgstr "Claudàtor esquerre de vector"
+
+#: ../src/interface.cc:1037 ../src/interface.cc:4000
+msgid "Right parenthesis"
+msgstr "Parèntesi dret"
+
+#: ../src/interface.cc:1037 ../src/interface.cc:4000
+msgid "Right vector bracket"
+msgstr "Claudàtor dret de vector"
+
+#: ../src/interface.cc:1048 ../src/interface.cc:4011
+msgid "Decimal point"
+msgstr "Punt decimal"
+
+#: ../src/interface.cc:1063
+msgid "Raise (Ctrl+*)"
+msgstr "Exponencia (Ctrl+*)"
+
+#: ../src/interface.cc:1091 ../src/interface.cc:4018
+msgid "Add"
+msgstr "Addiciona"
+
+#: ../src/interface.cc:1091 ../src/interface.cc:4018 ../src/callbacks.cc:3610
+#: ../src/callbacks.cc:6216 ../src/callbacks.cc:27594
+msgid "M+ (memory plus)"
+msgstr "M+ (afegeix a la memòria)"
+
+#: ../src/interface.cc:1096 ../src/interface.cc:4022 ../src/callbacks.cc:3604
+#: ../src/callbacks.cc:6213 ../src/callbacks.cc:27591
+msgid "MC (memory clear)"
+msgstr "MC (neteja la memòria)"
+
+#: ../src/interface.cc:1097 ../src/interface.cc:4023
+msgid "Backspace"
+msgstr "Retrocés"
+
+#: ../src/interface.cc:1097 ../src/interface.cc:4023 ../src/callbacks.cc:3613
+#: ../src/callbacks.cc:6217 ../src/callbacks.cc:27595
+msgid "M− (memory minus)"
+msgstr "M− (elimina de la memòria)"
+
+#: ../src/interface.cc:1098 ../src/interface.cc:4024
+msgid "Previous result (static)"
+msgstr "Resultat previ (estàtic)"
+
+#: ../src/interface.cc:1106 ../src/interface.cc:4025 ../src/callbacks.cc:1462
+#: ../src/callbacks.cc:14056
+msgid "Calculate expression"
+msgstr "Calcula l'expressió"
+
+#: ../src/interface.cc:1106 ../src/interface.cc:4025 ../src/callbacks.cc:6214
+#: ../src/callbacks.cc:27592
+msgid "MR (memory recall)"
+msgstr "MR (retira de la memòria)"
+
+#: ../src/interface.cc:1106 ../src/interface.cc:4025 ../src/callbacks.cc:3607
+#: ../src/callbacks.cc:6215 ../src/callbacks.cc:27593
+msgid "MS (memory store)"
+msgstr "MS (desa a la memòria)"
+
+#: ../src/interface.cc:1289 ../src/callbacks.cc:6180
+msgid "Set unknowns"
+msgstr "Estableix les desconegudes"
+
+#. Show further items in a submenu
+#: ../src/interface.cc:1337 ../src/interface.cc:1425 ../src/interface.cc:1428
+#: ../src/callbacks.cc:6522 ../src/callbacks.cc:6609 ../src/callbacks.cc:22679
+#: ../src/callbacks.cc:27277 ../src/callbacks.cc:27280
+#: ../src/callbacks.cc:27304
+msgid "more"
+msgstr "més"
+
+#: ../src/interface.cc:1487
+msgid "Logical AND"
+msgstr "AND lógic"
+
+#: ../src/interface.cc:1488
+msgid "Logical OR"
+msgstr "OR lógic"
+
+#: ../src/interface.cc:1489
+msgid "Logical NOT"
+msgstr "NOT lógic"
+
+#: ../src/interface.cc:1491 ../src/interface.cc:1492 ../src/interface.cc:1493
+#: ../src/interface.cc:1494
+msgid "Toggle Result Base"
+msgstr "Commuta la base del resultat"
+
+#: ../src/interface.cc:1496
+msgid "Open menu with stored variables"
+msgstr "Obre un menú amb les variables emmagatzemades"
+
+#: ../src/interface.cc:2073 ../src/interface.cc:2123
+msgid "Index"
+msgstr "Índex"
+
+#. RPN Enter (calculate and add to stack)
+#: ../src/interface.cc:2140 ../src/callbacks.cc:14028
+msgid "ENTER"
+msgstr "RETORN"
+
+#: ../src/interface.cc:2141 ../src/interface.cc:2142 ../src/callbacks.cc:1462
+#: ../src/callbacks.cc:14029
+msgid "Calculate expression and add to stack"
+msgstr "Calcula l'expressió i afegeix-la a la pila"
+
+#: ../src/interface.cc:2218 ../src/interface.cc:2436
+msgid "Flag"
+msgstr "Bandera"
+
+#: ../src/interface.cc:3022 ../src/callbacks.cc:17566 ../src/callbacks.cc:27707
+msgid "Matrices"
+msgstr "Matrius"
+
+#: ../src/interface.cc:3570
+msgid "Gregorian"
+msgstr "Gregorià"
+
+#: ../src/interface.cc:3571
+msgid "Revised Julian (Milanković)"
+msgstr "Julià revisat (Milanković)"
+
+#: ../src/interface.cc:3572
+msgid "Julian"
+msgstr "Julià"
+
+#: ../src/interface.cc:3573
+msgid "Islamic (Hijri)"
+msgstr "Islàmic (Hijri)"
+
+#: ../src/interface.cc:3574
+msgid "Hebrew"
+msgstr "Hebreu"
+
+#: ../src/interface.cc:3575
+msgid "Chinese"
+msgstr "Xinés"
+
+#: ../src/interface.cc:3576
+msgid "Persian (Solar Hijri)"
+msgstr "Persià (Hijri solar)"
+
+#: ../src/interface.cc:3577
+msgid "Coptic"
+msgstr "Copt"
+
+#: ../src/interface.cc:3578
+msgid "Ethiopian"
+msgstr "Etíop"
+
+#: ../src/interface.cc:3579
+msgid "Indian (National)"
+msgstr "Indi (nacional)"
+
+#: ../src/interface.cc:3894 ../src/interface.cc:3916 ../src/interface.cc:4082
+msgid "Action"
+msgstr "Acció"
+
+#: ../src/interface.cc:3902
+msgid "Key combination"
+msgstr "Combinació de teclats"
+
+#: ../src/interface.cc:4015
+msgid "Raise"
+msgstr "Exponencia"
+
+#: ../src/callbacks.cc:467
+msgid "History Answer Value"
+msgstr "Valor de resposta de l'historial"
+
+#: ../src/callbacks.cc:469 ../src/callbacks.cc:492
+msgid "History Index(es)"
+msgstr "Índex(es) de l'historial"
+
+#: ../src/callbacks.cc:480 ../src/callbacks.cc:503
+#, c-format
+msgid "History index %s does not exist."
+msgstr "L'índex d'historial %s no existeix."
+
+#: ../src/callbacks.cc:490 ../src/callbacks.cc:491 ../src/callbacks.cc:16967
+msgid "expression"
+msgstr "expressió"
+
+#: ../src/callbacks.cc:490
+msgid "History Parsed Expression"
+msgstr "Expressió analitzada de l'historial"
+
+#: ../src/callbacks.cc:513
+msgid "Set Window Title"
+msgstr "Estableix el títol de la finestra"
+
+#: ../src/callbacks.cc:1035 ../src/callbacks.cc:13966 ../src/callbacks.cc:31913
+#, c-format
+msgid ""
+"Failed to open %s.\n"
+"%s"
+msgstr ""
+"S'ha fallat en obrir %s.\n"
+"%s"
+
+#: ../src/callbacks.cc:1053
+msgid "Could not display help for Qalculate!."
+msgstr "No s'ha pogut mostrar l'ajuda del Qalculate!."
+
+#: ../src/callbacks.cc:1150
+#, c-format
+msgid ""
+"Could not display help for Qalculate!.\n"
+"%s"
+msgstr ""
+"No s'ha pogut mostrar l'ajuda del Qalculate!.\n"
+"%s"
+
+#: ../src/callbacks.cc:1182 ../src/callbacks.cc:7663 ../src/callbacks.cc:9933
+#: ../src/callbacks.cc:10288 ../src/callbacks.cc:10333
+#: ../src/callbacks.cc:10630 ../src/callbacks.cc:11198
+#: ../src/callbacks.cc:11253 ../src/callbacks.cc:14515
+#: ../src/callbacks.cc:25488 ../src/searchprovider.cc:119
+#: ../src/searchprovider.cc:120 ../src/searchprovider.cc:203
+msgid "approx."
+msgstr "aprox."
+
+#: ../src/callbacks.cc:1444
+msgid "Stop process"
+msgstr "Atura el procés"
+
+#: ../src/callbacks.cc:1455 ../src/callbacks.cc:23972
+msgid "Clear expression"
+msgstr "Neteja l'expressió"
+
+#: ../src/callbacks.cc:1958
+msgid "EXACT"
+msgstr "EXACTE"
+
+#: ../src/callbacks.cc:1961
+msgid "APPROX"
+msgstr "APROX"
+
+#: ../src/callbacks.cc:1965
+msgid "RPN"
+msgstr "NPI"
+
+#. Chain mode
+#: ../src/callbacks.cc:1970
+msgid "CHN"
+msgstr "CDN"
+
+#: ../src/callbacks.cc:1998
+msgid "ROMAN"
+msgstr "ROMAN"
+
+#: ../src/callbacks.cc:2050
+msgid "DEG"
+msgstr "DEG"
+
+#: ../src/callbacks.cc:2055
+msgid "RAD"
+msgstr "RAD"
+
+#: ../src/callbacks.cc:2060
+msgid "GRA"
+msgstr "GRA"
+
+#: ../src/callbacks.cc:2067
+msgid "PREC"
+msgstr "PREC"
+
+#: ../src/callbacks.cc:2072
+msgid "FUNC"
+msgstr "FUNC"
+
+#: ../src/callbacks.cc:2078
+msgid "UNIT"
+msgstr "UNIT"
+
+#: ../src/callbacks.cc:2084
+msgid "VAR"
+msgstr "VAR"
+
+#: ../src/callbacks.cc:2090
+msgid "INF"
+msgstr "INF"
+
+#: ../src/callbacks.cc:2096
+msgid "CPLX"
+msgstr "CPLX"
+
+#: ../src/callbacks.cc:2122
+msgid "Do you wish to update the exchange rates now?"
+msgstr "Voleu actualitzar les taxes d'intercanvi ara?"
+
+#: ../src/callbacks.cc:2124
+#, c-format
+msgid "It has been %s day since the exchange rates last were updated."
+msgid_plural "It has been %s days since the exchange rates last were updated."
+msgstr[0] "Fa %s dia que es van actualitzar les taxes d'intercanvi."
+msgstr[1] "Fa %s dies que es van actualitzar les taxes d'intercanvi."
+
+#: ../src/callbacks.cc:2125
+msgid "Do not ask again"
+msgstr "No tornis a preguntar"
+
+#: ../src/callbacks.cc:2179 ../src/callbacks.cc:34478 ../src/callbacks.cc:34489
+#: ../src/callbacks.cc:34499
+msgid "It took too long to generate the plot data."
+msgstr "Ha trigat massa temps generar les dades a dibuixar."
+
+#: ../src/callbacks.cc:2179
+msgid ""
+"It took too long to generate the plot data. Please decrease the sampling "
+"rate or increase the time limit in preferences."
+msgstr ""
+"Ha trigat massa temps generar les dades a dibuixar. Si us plau, disminuïu la "
+"taxa de mostreig o augmenta el límit de temps en les preferències."
+
+#: ../src/callbacks.cc:2263
+msgid ""
+"When errors, warnings and other information are generated during "
+"calculation, the icon in the upper right corner of the expression entry "
+"changes to reflect this. If you hold the pointer over or click the icon, the "
+"message will be shown."
+msgstr ""
+"Quan es generen errors, advertències i altra informació durant el càlcul, la "
+"icona en la cantonada dreta superior de l'entrada d'expressió canvia per a "
+"reflectir això. Si mantingueu el punter sobre la icona o feu clic en ella, "
+"el missatge es mostrarà."
+
+#: ../src/callbacks.cc:2342
+msgid "Path of executable not found."
+msgstr "No s'ha trobat el camí de l'executable."
+
+#: ../src/callbacks.cc:2352
+msgid "curl not found."
+msgstr "No s'ha trobat curl."
+
+#: ../src/callbacks.cc:2410
+#, c-format
+msgid ""
+"Failed to run update script.\n"
+"%s"
+msgstr ""
+"S'ha fallat en executar l'script d'actualització.\n"
+"%s"
+
+#: ../src/callbacks.cc:2430
+msgid "Failed to check for updates."
+msgstr "S'ha fallat en cercar actualitzacions."
+
+#: ../src/callbacks.cc:2430
+msgid "No updates found."
+msgstr "No s'ha trobat cap actualització."
+
+#: ../src/callbacks.cc:2450
+#, c-format
+msgid ""
+"A new version of %s is available at %s.\n"
+"\n"
+"Do you wish to update to version %s?"
+msgstr ""
+"Una versió nova de %s està disponible a %s.\n"
+"\n"
+"Voleu actualitzar a la versió %s?"
+
+#: ../src/callbacks.cc:2452
+#, c-format
+msgid ""
+"A new version of %s is available.\n"
+"\n"
+"You can get version %s at %s."
+msgstr ""
+"Una versió nova de %s està disponible.\n"
+"\n"
+"Podeu aconseguir la versió %s a %s."
+
+#: ../src/callbacks.cc:2488
+#, c-format
+msgid "Too many arguments for %s()."
+msgstr "Hi ha massa arguments per a %s()."
+
+#: ../src/callbacks.cc:2515 ../src/callbacks.cc:4533 ../src/callbacks.cc:5758
+msgid "argument"
+msgstr "argument"
+
+#: ../src/callbacks.cc:2685
+msgid "Temperature Calculation Mode"
+msgstr "Mode de càlcul de temperatura"
+
+#: ../src/callbacks.cc:2695
+msgid ""
+"The expression is ambiguous.\n"
+"Please select temperature calculation mode\n"
+"(the mode can later be changed in preferences)."
+msgstr ""
+"L'expressió és ambigua.\n"
+"Si us plau, seleccioneu el mode de càlcul de temperatura\n"
+"(es pot canviar el mode després en les preferències)."
+
+#: ../src/callbacks.cc:2774
+msgid "Interpretation of dots"
+msgstr "Interpretació de punts"
+
+#: ../src/callbacks.cc:2784
+msgid ""
+"Please select interpretation of dots (\".\")\n"
+"(this can later be changed in preferences)."
+msgstr ""
+"Si us plau, seleccioneu la interpretació de punts (\".\")\n"
+"(es pot canviar això després en les preferències)."
+
+#: ../src/callbacks.cc:2787
+msgid "Both dot and comma as decimal separators"
+msgstr "Ambdós punt i coma com a separadors decimals"
+
+#: ../src/callbacks.cc:2794
+msgid "Dot as thousands separator"
+msgstr "Punt com a separador de millars"
+
+#: ../src/callbacks.cc:2801
+msgid "Only dot as decimal separator"
+msgstr "Només punt com a separador decimal"
+
+#: ../src/callbacks.cc:2864 ../src/callbacks.cc:4399 ../src/callbacks.cc:4400
+#: ../src/callbacks.cc:4456 ../src/callbacks.cc:4762 ../src/callbacks.cc:4763
+#: ../src/callbacks.cc:4882 ../src/callbacks.cc:5019 ../src/callbacks.cc:5020
+#: ../src/callbacks.cc:5123 ../src/callbacks.cc:5266 ../src/callbacks.cc:5267
+#: ../src/callbacks.cc:5268 ../src/callbacks.cc:5527 ../src/callbacks.cc:13937
+#: ../src/callbacks.cc:15455 ../src/callbacks.cc:15829
+#: ../src/callbacks.cc:16146 ../src/callbacks.cc:16365
+#: ../src/callbacks.cc:16652
+msgid "Uncategorized"
+msgstr "Sense categoria"
+
+#: ../src/callbacks.cc:3045 ../src/callbacks.cc:3776 ../src/callbacks.cc:13256
+msgid "hexadecimal"
+msgstr "hexadecimal"
+
+#: ../src/callbacks.cc:3048 ../src/callbacks.cc:3778 ../src/callbacks.cc:13259
+msgid "octal"
+msgstr "octal"
+
+#: ../src/callbacks.cc:3051 ../src/callbacks.cc:3780 ../src/callbacks.cc:13262
+msgid "decimal"
+msgstr "decimal"
+
+#: ../src/callbacks.cc:3054 ../src/callbacks.cc:3782 ../src/callbacks.cc:13265
+msgid "duodecimal"
+msgstr "duodecimal"
+
+#: ../src/callbacks.cc:3057 ../src/callbacks.cc:3784 ../src/callbacks.cc:13268
+msgid "binary"
+msgstr "binària"
+
+#: ../src/callbacks.cc:3060 ../src/callbacks.cc:3786 ../src/callbacks.cc:13271
+msgid "roman"
+msgstr "romana"
+
+#: ../src/callbacks.cc:3063 ../src/callbacks.cc:3788 ../src/callbacks.cc:13274
+msgid "bijective"
+msgstr "bijectiva"
+
+#: ../src/callbacks.cc:3066 ../src/callbacks.cc:3069 ../src/callbacks.cc:3072
+#: ../src/callbacks.cc:3790 ../src/callbacks.cc:13277 ../src/callbacks.cc:13280
+#: ../src/callbacks.cc:13283
+msgid "sexagesimal"
+msgstr "sexagesimal"
+
+#: ../src/callbacks.cc:3075 ../src/callbacks.cc:3078 ../src/callbacks.cc:3792
+#: ../src/callbacks.cc:3793 ../src/callbacks.cc:13286 ../src/callbacks.cc:13289
+msgid "latitude"
+msgstr "latitud"
+
+#: ../src/callbacks.cc:3081 ../src/callbacks.cc:3084 ../src/callbacks.cc:3794
+#: ../src/callbacks.cc:3795 ../src/callbacks.cc:13292 ../src/callbacks.cc:13295
+msgid "longitude"
+msgstr "longitud"
+
+#: ../src/callbacks.cc:3102 ../src/callbacks.cc:3806 ../src/callbacks.cc:13313
+msgid "time"
+msgstr "temps"
+
+#: ../src/callbacks.cc:3153 ../src/callbacks.cc:3810 ../src/callbacks.cc:13390
+msgid "bases"
+msgstr "bases"
+
+#: ../src/callbacks.cc:3155 ../src/callbacks.cc:3812 ../src/callbacks.cc:3813
+#: ../src/callbacks.cc:13400
+msgid "calendars"
+msgstr "calendaris"
+
+#: ../src/callbacks.cc:3157 ../src/callbacks.cc:3826 ../src/callbacks.cc:13410
+msgid "rectangular"
+msgstr "rectangular"
+
+#: ../src/callbacks.cc:3157 ../src/callbacks.cc:3826 ../src/callbacks.cc:13410
+msgid "cartesian"
+msgstr "cartesià"
+
+#: ../src/callbacks.cc:3161 ../src/callbacks.cc:3828 ../src/callbacks.cc:13422
+msgid "exponential"
+msgstr "exponencial"
+
+#: ../src/callbacks.cc:3165 ../src/callbacks.cc:3830 ../src/callbacks.cc:13434
+msgid "polar"
+msgstr "polar"
+
+#: ../src/callbacks.cc:3173 ../src/callbacks.cc:3834 ../src/callbacks.cc:13460
+msgid "angle"
+msgstr "angle"
+
+#: ../src/callbacks.cc:3173 ../src/callbacks.cc:3836 ../src/callbacks.cc:13460
+msgid "phasor"
+msgstr "fasor"
+
+#: ../src/callbacks.cc:3177 ../src/callbacks.cc:3814 ../src/callbacks.cc:13472
+msgid "optimal"
+msgstr "òptima"
+
+#: ../src/callbacks.cc:3182 ../src/callbacks.cc:3201 ../src/callbacks.cc:3816
+#: ../src/callbacks.cc:3891 ../src/callbacks.cc:13484 ../src/callbacks.cc:13534
+msgid "base"
+msgstr "base"
+
+#: ../src/callbacks.cc:3187 ../src/callbacks.cc:3818 ../src/callbacks.cc:13496
+msgid "mixed"
+msgstr "mixta"
+
+#: ../src/callbacks.cc:3192 ../src/callbacks.cc:3820 ../src/callbacks.cc:3821
+#: ../src/callbacks.cc:13511
+msgid "fraction"
+msgstr "fracció"
+
+#: ../src/callbacks.cc:3195 ../src/callbacks.cc:3822 ../src/callbacks.cc:3823
+#: ../src/callbacks.cc:13514
+msgid "factors"
+msgstr "factors"
+
+#: ../src/callbacks.cc:3198 ../src/callbacks.cc:3824 ../src/callbacks.cc:13524
+msgid "partial fraction"
+msgstr "fracció parcial"
+
+#: ../src/callbacks.cc:3229 ../src/callbacks.cc:3620 ../src/callbacks.cc:3622
+#: ../src/callbacks.cc:13577 ../src/searchprovider.cc:161
+msgid "factorize"
+msgstr "factoritza"
+
+#: ../src/callbacks.cc:3232 ../src/callbacks.cc:3623 ../src/callbacks.cc:3625
+#: ../src/callbacks.cc:13580 ../src/searchprovider.cc:161
+msgid "expand"
+msgstr "expandeix"
+
+#: ../src/callbacks.cc:3777 ../src/callbacks.cc:3887
+msgid "hexadecimal number"
+msgstr "nombre hexadecimal"
+
+#: ../src/callbacks.cc:3779
+msgid "octal number"
+msgstr "nombre octal"
+
+#: ../src/callbacks.cc:3781
+msgid "decimal number"
+msgstr "nombre decimal"
+
+#: ../src/callbacks.cc:3783
+msgid "duodecimal number"
+msgstr "nombre duodecimal"
+
+#: ../src/callbacks.cc:3785 ../src/callbacks.cc:3881
+msgid "binary number"
+msgstr "nombre binari"
+
+#: ../src/callbacks.cc:3787
+msgid "roman numerals"
+msgstr "numerals romans"
+
+#: ../src/callbacks.cc:3789
+msgid "bijective base-26"
+msgstr "base 26 bijectiva"
+
+#: ../src/callbacks.cc:3791
+msgid "sexagesimal number"
+msgstr "nombre sexagesimal"
+
+#: ../src/callbacks.cc:3797
+msgid "32-bit floating point"
+msgstr "punt flotant de 32 bits"
+
+#: ../src/callbacks.cc:3799
+msgid "64-bit floating point"
+msgstr "punt flotant de 64 bits"
+
+#: ../src/callbacks.cc:3801
+msgid "16-bit floating point"
+msgstr "punt flotant de 16 bis"
+
+#: ../src/callbacks.cc:3803
+msgid "80-bit (x86) floating point"
+msgstr "punt flotant de 80 bits (x86)"
+
+#: ../src/callbacks.cc:3805
+msgid "128-bit floating point"
+msgstr "punt flotant de 128 bits"
+
+#: ../src/callbacks.cc:3807
+msgid "time format"
+msgstr "format de temps"
+
+#: ../src/callbacks.cc:3811
+msgid "number bases"
+msgstr "bases numèriques"
+
+#: ../src/callbacks.cc:3815
+msgid "optimal unit"
+msgstr "unitat òptima"
+
+#: ../src/callbacks.cc:3817
+msgid "base units"
+msgstr "unitats bases"
+
+#: ../src/callbacks.cc:3819
+msgid "mixed units"
+msgstr "unitats mixtes"
+
+#: ../src/callbacks.cc:3825
+msgid "expanded partial fractions"
+msgstr "fraccions parcials expandides"
+
+#: ../src/callbacks.cc:3827
+msgid "complex rectangular form"
+msgstr "forma rectangular complexa"
+
+#: ../src/callbacks.cc:3829
+msgid "complex exponential form"
+msgstr "forma exponencial complexa"
+
+#: ../src/callbacks.cc:3831
+msgid "complex polar form"
+msgstr "forma polar complexa"
+
+#: ../src/callbacks.cc:3833
+msgid "complex cis form"
+msgstr "forma cis complexa"
+
+#: ../src/callbacks.cc:3835
+msgid "complex angle notation"
+msgstr "notació complexa d'angle"
+
+#: ../src/callbacks.cc:3837
+msgid "complex phasor notation"
+msgstr "notació complexa de fasor"
+
+#: ../src/callbacks.cc:3839 ../src/callbacks.cc:7283
+msgid "UTC time zone"
+msgstr "Zona horària UTC"
+
+#: ../src/callbacks.cc:3892
+#, c-format
+msgid "number base %s"
+msgstr "base numèrica %s"
+
+#: ../src/callbacks.cc:4408 ../src/callbacks.cc:4409 ../src/callbacks.cc:4458
+#: ../src/callbacks.cc:4771 ../src/callbacks.cc:4772 ../src/callbacks.cc:4884
+#: ../src/callbacks.cc:5027 ../src/callbacks.cc:5028 ../src/callbacks.cc:5125
+#: ../src/callbacks.cc:15453 ../src/callbacks.cc:15827
+#: ../src/callbacks.cc:16144 ../src/callbacks.cc:16363
+#: ../src/callbacks.cc:16650
+msgid "Inactive"
+msgstr "Desactivat"
+
+#: ../src/callbacks.cc:4560
+#, c-format
+msgid ""
+"Retrieves data from the %s data set for a given object and property. If "
+"\"info\" is typed as property, a dialog window will pop up with all "
+"properties of the object."
+msgstr ""
+"Obté dades del conjunt de dades %s per a un objecte i una propietat donats. "
+"Si \"info\" és de tipus propietat, una finestra de diàleg emergirà amb totes "
+"les propietats de l'objecte."
+
+#: ../src/callbacks.cc:4572 ../src/callbacks.cc:15000
+msgid "Example:"
+msgstr "Exemple:"
+
+#: ../src/callbacks.cc:4586
+msgid "Arguments"
+msgstr "Arguments"
+
+#. optional argument
+#: ../src/callbacks.cc:4611 ../src/callbacks.cc:14872 ../src/callbacks.cc:14883
+msgid "optional"
+msgstr "opcional"
+
+#. argument default, in description
+#: ../src/callbacks.cc:4615
+msgid "default: "
+msgstr "default: "
+
+#: ../src/callbacks.cc:4630
+msgid "Requirement"
+msgstr "Requisit"
+
+#. indicating that the property is a data set key
+#: ../src/callbacks.cc:4664 ../src/callbacks.cc:5713 ../src/callbacks.cc:16973
+msgid "key"
+msgstr "clau"
+
+#: ../src/callbacks.cc:4685 ../src/callbacks.cc:4946 ../src/callbacks.cc:5196
+msgid "Acti_vate"
+msgstr "Acti_va"
+
+#: ../src/callbacks.cc:4789 ../src/callbacks.cc:7003
+msgid "a previous result"
+msgstr "un resultat prèvi"
+
+#: ../src/callbacks.cc:4814 ../src/callbacks.cc:7012
+msgid "matrix"
+msgstr "matriu"
+
+#: ../src/callbacks.cc:4816 ../src/callbacks.cc:7014
+msgid "vector"
+msgstr "vector"
+
+#: ../src/callbacks.cc:4826 ../src/callbacks.cc:7025
+msgid "positive"
+msgstr "positiu"
+
+#: ../src/callbacks.cc:4827 ../src/callbacks.cc:7026
+msgid "non-positive"
+msgstr "no positiu"
+
+#: ../src/callbacks.cc:4828 ../src/callbacks.cc:7027
+msgid "negative"
+msgstr "negatiu"
+
+#: ../src/callbacks.cc:4829 ../src/callbacks.cc:7028
+msgid "non-negative"
+msgstr "no negatiu"
+
+#: ../src/callbacks.cc:4830 ../src/callbacks.cc:7029
+msgid "non-zero"
+msgstr "no zero"
+
+#: ../src/callbacks.cc:4835 ../src/callbacks.cc:7034
+msgid "boolean"
+msgstr "booleà"
+
+#: ../src/callbacks.cc:4836 ../src/callbacks.cc:7035
+msgid "integer"
+msgstr "enter"
+
+#: ../src/callbacks.cc:4837 ../src/callbacks.cc:7036
+msgid "rational"
+msgstr "racional"
+
+#: ../src/callbacks.cc:4838 ../src/callbacks.cc:7037
+msgid "real"
+msgstr "real"
+
+#: ../src/callbacks.cc:4839 ../src/callbacks.cc:7038
+msgid "complex"
+msgstr "complex"
+
+#: ../src/callbacks.cc:4840 ../src/callbacks.cc:7039 ../src/callbacks.cc:16959
+msgid "number"
+msgstr "nombre"
+
+#: ../src/callbacks.cc:4841 ../src/callbacks.cc:7040
+msgid "(not matrix)"
+msgstr "(no matriu)"
+
+#: ../src/callbacks.cc:4844 ../src/callbacks.cc:7043
+msgid "unknown"
+msgstr "desconegut"
+
+#: ../src/callbacks.cc:4846 ../src/callbacks.cc:7045
+msgid "default assumptions"
+msgstr "suposicions predeterminades"
+
+#: ../src/callbacks.cc:4930 ../src/callbacks.cc:15064 ../src/callbacks.cc:15073
+#: ../src/callbacks.cc:16166 ../src/callbacks.cc:30139
+#: ../src/callbacks.cc:30154 ../src/callbacks.cc:30172
+#: ../src/callbacks.cc:30205
+msgid "Variable does not exist anymore."
+msgstr "La variable ja no existeix."
+
+#: ../src/callbacks.cc:5729
+msgid "Data Retrieval Function"
+msgstr "Funció d'obteniment de dades"
+
+#: ../src/callbacks.cc:6162
+msgid "Insert function"
+msgstr "Insereix una funció"
+
+#: ../src/callbacks.cc:6163
+msgid "Insert function (dialog)"
+msgstr "Insereix una funció (diàleg)"
+
+#: ../src/callbacks.cc:6164
+msgid "Insert variable"
+msgstr "Insereix una variable"
+
+#: ../src/callbacks.cc:6165
+msgid "Insert unit"
+msgstr "Insereix una unitat"
+
+#: ../src/callbacks.cc:6166
+msgid "Insert text"
+msgstr "Insereix text"
+
+#: ../src/callbacks.cc:6167
+msgid "Insert date"
+msgstr "Insereix una data"
+
+#: ../src/callbacks.cc:6168
+msgid "Insert vector"
+msgstr "Insereix un vector"
+
+#: ../src/callbacks.cc:6169
+msgid "Insert matrix"
+msgstr "Insereix una matriu"
+
+#: ../src/callbacks.cc:6170
+msgid "Insert smart parentheses"
+msgstr "Insereix parèntesis intel·ligents"
+
+#: ../src/callbacks.cc:6171
+msgid "Convert to unit"
+msgstr "Converteix a altra unitat"
+
+#: ../src/callbacks.cc:6172
+msgid "Convert to unit (entry)"
+msgstr "Converteix a altra unitat (entrada)"
+
+#: ../src/callbacks.cc:6173
+msgid "Convert to optimal unit"
+msgstr "Converteix a la unitat òptima"
+
+#: ../src/callbacks.cc:6174
+msgid "Convert to base units"
+msgstr "Converteix a les unitats bases"
+
+#: ../src/callbacks.cc:6175
+msgid "Convert to optimal prefix"
+msgstr "Converteix al prefix òptim"
+
+#: ../src/callbacks.cc:6176
+msgid "Convert to number base"
+msgstr "Converteix a la base numèrica"
+
+#: ../src/callbacks.cc:6177
+msgid "Factorize result"
+msgstr "Factoritza el resultat"
+
+#: ../src/callbacks.cc:6178
+msgid "Expand result"
+msgstr "Expandeix el resultat"
+
+#: ../src/callbacks.cc:6179
+msgid "Expand partial fractions"
+msgstr "Expandeix les fraccions parcials"
+
+#: ../src/callbacks.cc:6181
+msgid "RPN: down"
+msgstr "NPI: avall"
+
+#: ../src/callbacks.cc:6182
+msgid "RPN: up"
+msgstr "NPI: amunt"
+
+#: ../src/callbacks.cc:6183
+msgid "RPN: swap"
+msgstr "NPI: intercanvia"
+
+#: ../src/callbacks.cc:6184
+msgid "RPN: copy"
+msgstr "NPI: copia"
+
+#: ../src/callbacks.cc:6185
+msgid "RPN: lastx"
+msgstr "RPN: última x"
+
+#: ../src/callbacks.cc:6186
+msgid "RPN: delete register"
+msgstr "NPI: suprimeix el registre"
+
+#: ../src/callbacks.cc:6187
+msgid "RPN: clear stack"
+msgstr "NPI: neteja la pila"
+
+#: ../src/callbacks.cc:6188
+msgid "Load meta mode"
+msgstr "Carrega el mode meta"
+
+#: ../src/callbacks.cc:6189
+msgid "Set expression base"
+msgstr "Estableix la base d'expressió"
+
+#: ../src/callbacks.cc:6190
+msgid "Set result base"
+msgstr "Estableix la base del resultat"
+
+#: ../src/callbacks.cc:6191
+msgid "Toggle exact mode"
+msgstr "Commuta el mode exacte"
+
+#: ../src/callbacks.cc:6192
+msgid "Set angle unit to degrees"
+msgstr "Estableix la unitat d'angle com a graus"
+
+#: ../src/callbacks.cc:6193
+msgid "Set angle unit to radians"
+msgstr "Estableix la unitat d'angle com a radians"
+
+#: ../src/callbacks.cc:6194
+msgid "Set angle unit to gradians"
+msgstr "Estableix la unitat d'angle com a gradians"
+
+#: ../src/callbacks.cc:6195
+msgid "Toggle simple fractions"
+msgstr "Commuta les fraccions senzilles"
+
+#: ../src/callbacks.cc:6196
+msgid "Toggle mixed fractions"
+msgstr "Commuta les fraccions mixtes"
+
+#: ../src/callbacks.cc:6197
+msgid "Toggle scientific notation"
+msgstr "Commuta la notació científica"
+
+#: ../src/callbacks.cc:6198
+msgid "Toggle simple notation"
+msgstr "Commuta la notació senzilla"
+
+#: ../src/callbacks.cc:6199
+msgid "Toggle RPN mode"
+msgstr "Commuta el mode NPI"
+
+#: ../src/callbacks.cc:6200
+msgid "Toggle calculate as you type"
+msgstr "Commuta el càlcul mentre teclegeu"
+
+#: ../src/callbacks.cc:6201
+msgid "Toggle programming keypad"
+msgstr "Commuta el teclat programari"
+
+#: ../src/callbacks.cc:6202
+msgid "Show keypad"
+msgstr "Mostra el teclat numèric"
+
+#: ../src/callbacks.cc:6203
+msgid "Show history"
+msgstr "Mostra l'historial"
+
+#: ../src/callbacks.cc:6204
+msgid "Search history"
+msgstr "Cerca en l'historial"
+
+#: ../src/callbacks.cc:6205
+msgid "Show conversion"
+msgstr "Mostra la conversió"
+
+#: ../src/callbacks.cc:6206
+msgid "Show RPN stack"
+msgstr "Mostra la pila NPI"
+
+#: ../src/callbacks.cc:6208
+msgid "Manage variables"
+msgstr "Gestiona les variables"
+
+#: ../src/callbacks.cc:6209
+msgid "Manage functions"
+msgstr "Gestiona les funcions"
+
+#: ../src/callbacks.cc:6211
+msgid "Manage data sets"
+msgstr "Gestiona els conjunts de dades"
+
+#: ../src/callbacks.cc:6218
+msgid "New variable"
+msgstr "Variable nova"
+
+#: ../src/callbacks.cc:6219
+msgid "New function"
+msgstr "Funció nova"
+
+#: ../src/callbacks.cc:6220
+msgid "Open plot functions/data"
+msgstr "Obre el dibuix de funcions/dades"
+
+#: ../src/callbacks.cc:6221
+msgid "Open convert number bases"
+msgstr "Obre la conversió de bases numèriques"
+
+#: ../src/callbacks.cc:6222
+msgid "Open floating point conversion"
+msgstr "Obre la conversió de punt flotant"
+
+#: ../src/callbacks.cc:6223
+msgid "Open calender conversion"
+msgstr "Obre la conversió de calendari"
+
+#: ../src/callbacks.cc:6224
+msgid "Open percentage calculation tool"
+msgstr "Obre l'eina de càlcul de percentatge"
+
+#: ../src/callbacks.cc:6225
+msgid "Open periodic table"
+msgstr "Obre la taula periòdica"
+
+#: ../src/callbacks.cc:6226
+msgid "Update exchange rates"
+msgstr "Actualitza les taxes d'intercanvi"
+
+#: ../src/callbacks.cc:6227
+msgid "Copy result"
+msgstr "Copia el resultat"
+
+#: ../src/callbacks.cc:6228
+msgid "Insert result"
+msgstr "Insereix el resultat"
+
+#: ../src/callbacks.cc:6229
+msgid "Save result image"
+msgstr "Desa una imatge del resultat"
+
+#: ../src/callbacks.cc:6230
+msgid "Help"
+msgstr "Ajuda"
+
+#: ../src/callbacks.cc:6231
+msgid "Quit"
+msgstr "Surt"
+
+#: ../src/callbacks.cc:6232
+msgid "Toggle chain mode"
+msgstr "Commuta el mode de cadena"
+
+#: ../src/callbacks.cc:6233
+msgid "Toggle keep above"
+msgstr "Commuta el manteniment amunt"
+
+#: ../src/callbacks.cc:6234
+msgid "Show/hide completion"
+msgstr "Mostra/amaga la compleció"
+
+#: ../src/callbacks.cc:6235
+msgid "Perform completion (activate first item)"
+msgstr "Realitza la compleció (activa el primer element)"
+
+#: ../src/callbacks.cc:6554
+msgid "Prefixes"
+msgstr "Prefixes"
+
+#: ../src/callbacks.cc:6776
+msgid "No Prefix"
+msgstr "Cap prefix"
+
+#: ../src/callbacks.cc:6777
+msgid "Optimal Prefix"
+msgstr "Prefix òptim"
+
+#: ../src/callbacks.cc:7200 ../src/callbacks.cc:7204 ../src/callbacks.cc:7208
+msgid "Prefix"
+msgstr "Prefix"
+
+#: ../src/callbacks.cc:7221
+msgid "Complex angle/phasor notation"
+msgstr "Notació complexa d'angle o de fasor"
+
+#: ../src/callbacks.cc:7223 ../src/callbacks.cc:27156
+msgid "Number bases"
+msgstr "Bases numèriques"
+
+#: ../src/callbacks.cc:7225 ../src/callbacks.cc:27206
+msgid "Base units"
+msgstr "Unitats bases"
+
+#: ../src/callbacks.cc:7231
+msgid "Binary number"
+msgstr "Nombre binari"
+
+#: ../src/callbacks.cc:7233 ../src/callbacks.cc:27150
+msgid "Calendars"
+msgstr "Calendaris"
+
+#: ../src/callbacks.cc:7235
+msgid "Complex cis form"
+msgstr "Forma cis complexa"
+
+#: ../src/callbacks.cc:7237
+msgid "Decimal number"
+msgstr "Nombre decimal"
+
+#: ../src/callbacks.cc:7239
+msgid "Duodecimal number"
+msgstr "Nombre duodecimal"
+
+#: ../src/callbacks.cc:7241
+msgid "Complex exponential form"
+msgstr "Forma exponencial complexa"
+
+#: ../src/callbacks.cc:7243 ../src/callbacks.cc:27166 ../src/callbacks.cc:27170
+msgid "Factors"
+msgstr "Factors"
+
+#: ../src/callbacks.cc:7245
+msgid "16-bit floating point binary format"
+msgstr "Format binari de punt flotant de 16 bits"
+
+#: ../src/callbacks.cc:7247
+msgid "32-bit floating point binary format"
+msgstr "Format binari de punt flotant de 32 bits"
+
+#: ../src/callbacks.cc:7249
+msgid "64-bit floating point binary format"
+msgstr "Format binari de punt flotant de 64 bits"
+
+#: ../src/callbacks.cc:7251
+msgid "80-bit (x86) floating point binary format"
+msgstr "Format binari de punt flotant de 80 bits (x86)"
+
+#: ../src/callbacks.cc:7253
+msgid "128-bit floating point binary format"
+msgstr "Format binari de punt flotant de 128 bits"
+
+#: ../src/callbacks.cc:7257
+msgid "Hexadecimal number"
+msgstr "Nombre hexadecimal"
+
+#: ../src/callbacks.cc:7259
+msgid "Latitude"
+msgstr "Latitud"
+
+#: ../src/callbacks.cc:7261
+msgid "Longitude"
+msgstr "Longitud"
+
+#: ../src/callbacks.cc:7263
+msgid "Mixed units"
+msgstr "Unitats mixtes"
+
+#: ../src/callbacks.cc:7265
+msgid "Octal number"
+msgstr "Nombre octal"
+
+#: ../src/callbacks.cc:7267
+msgid "Optimal units"
+msgstr "Unitats òptimes"
+
+#: ../src/callbacks.cc:7269
+msgid "Expanded partial fractions"
+msgstr "Fraccions parcials expandides"
+
+#: ../src/callbacks.cc:7271
+msgid "Complex polar form"
+msgstr "Forma polar complex"
+
+#: ../src/callbacks.cc:7273
+msgid "Complex rectangular form"
+msgstr "Forma rectangular complex"
+
+#: ../src/callbacks.cc:7277
+msgid "Sexagesimal number"
+msgstr "Nombre sexagesimal"
+
+#: ../src/callbacks.cc:8847
+msgid "and"
+msgstr "and"
+
+#: ../src/callbacks.cc:8850 ../src/callbacks.cc:10436 ../src/callbacks.cc:10455
+#: ../src/callbacks.cc:10456
+msgid "or"
+msgstr "or"
+
+#: ../src/callbacks.cc:9850
+msgid "undefined"
+msgstr "sense definir"
+
+#: ../src/callbacks.cc:10176 ../src/callbacks.cc:32983
+msgid ""
+"result is too long\n"
+"see history"
+msgstr ""
+"el resultat és massa llarg\n"
+"vegeu l'historial"
+
+#: ../src/callbacks.cc:10201 ../src/callbacks.cc:33004
+msgid "calculation was aborted"
+msgstr "s'ha avortat el càlcul"
+
+#: ../src/callbacks.cc:10873 ../src/callbacks.cc:25457
+msgid "RPN Register Moved"
+msgstr "S'ha mogut el registre NPI"
+
+#: ../src/callbacks.cc:10881 ../src/callbacks.cc:13825
+#: ../src/callbacks.cc:25463
+msgid "RPN Operation"
+msgstr "Operació NPI"
+
+#: ../src/callbacks.cc:11087
+msgid "Processing…"
+msgstr "S'està processant…"
+
+#: ../src/callbacks.cc:11107 ../src/callbacks.cc:32983
+msgid "result processing was aborted"
+msgstr "s'ha avortat el processament del resultat"
+
+#: ../src/callbacks.cc:11521
+msgid "Factorizing…"
+msgstr "S'està factoritzant…"
+
+#: ../src/callbacks.cc:11525
+msgid "Expanding partial fractions…"
+msgstr "S'estan expandint les fraccions parcials…"
+
+#: ../src/callbacks.cc:11529
+msgid "Expanding…"
+msgstr "S'està expandint…"
+
+#: ../src/callbacks.cc:11534 ../src/callbacks.cc:13757
+msgid "Calculating…"
+msgstr "S'està calculant…"
+
+#: ../src/callbacks.cc:11538
+msgid "Converting…"
+msgstr "S'està convertint…"
+
+#: ../src/callbacks.cc:11641
+msgid "Fetching exchange rates."
+msgstr "S'estan obtenint les taxes d'intercanvi."
+
+#: ../src/callbacks.cc:13365
+msgid "Time zone parsing failed."
+msgstr "L'anàlisi de la zona horària ha fallat."
+
+#: ../src/callbacks.cc:14663
+msgid "Keep open"
+msgstr "Manté obert"
+
+#. RPN Enter (calculate and add to stack)
+#: ../src/callbacks.cc:14672
+msgid "Enter"
+msgstr "Introdueix"
+
+#: ../src/callbacks.cc:14672
+msgid "C_alculate"
+msgstr "C_alcula"
+
+#: ../src/callbacks.cc:14675
+msgid "Apply to Stack"
+msgstr "Aplica a la pila"
+
+#: ../src/callbacks.cc:14728
+msgid "Argument"
+msgstr "Argment"
+
+#: ../src/callbacks.cc:14788
+msgid "True"
+msgstr "Cert"
+
+#: ../src/callbacks.cc:14790
+msgid "False"
+msgstr "Fals"
+
+#: ../src/callbacks.cc:14835
+msgid "Info"
+msgstr "Info"
+
+#: ../src/callbacks.cc:15201
+msgid "Edit Unit (global)"
+msgstr "Edita la unitat (global)"
+
+#: ../src/callbacks.cc:15203
+msgid "New Unit"
+msgstr "Unitat nova"
+
+#: ../src/callbacks.cc:15327 ../src/callbacks.cc:15746
+#: ../src/callbacks.cc:15902 ../src/callbacks.cc:16099
+#: ../src/callbacks.cc:16311 ../src/callbacks.cc:16566
+#: ../src/callbacks.cc:17044 ../src/callbacks.cc:17195
+#: ../src/callbacks.cc:17309 ../src/callbacks.cc:18957
+#: ../src/callbacks.cc:33518
+msgid "Empty name field."
+msgstr "El camp de nom està buit."
+
+#. unit with the same name exists -- overwrite or open the dialog again
+#: ../src/callbacks.cc:15332
+msgid ""
+"A variable or unit with the same name already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+"Una variable o unitat amb el mateix nom ja existeix.\n"
+"Voleu sobreescriure-la?"
+
+#: ../src/callbacks.cc:15356 ../src/callbacks.cc:15408
+msgid "Base unit does not exist."
+msgstr "La unitat base no existeix."
+
+#: ../src/callbacks.cc:15664
+msgid "Edit Function (global)"
+msgstr "Edita la funció (global)"
+
+#: ../src/callbacks.cc:15666 ../src/callbacks.cc:15871
+msgid "New Function"
+msgstr "Funció nova"
+
+#: ../src/callbacks.cc:15717 ../src/callbacks.cc:33277
+#: ../src/callbacks.cc:33289
+msgid "Yes"
+msgstr "Sí"
+
+#: ../src/callbacks.cc:15719 ../src/callbacks.cc:33279
+#: ../src/callbacks.cc:33291
+msgid "No"
+msgstr "No"
+
+#: ../src/callbacks.cc:15762 ../src/callbacks.cc:15922
+msgid "Empty expression field."
+msgstr "El camp d'expressió està buit."
+
+#. function with the same name exists -- overwrite or open the dialog again
+#. dataset with the same name exists -- overwrite or open the dialog again
+#: ../src/callbacks.cc:15770 ../src/callbacks.cc:15926
+#: ../src/callbacks.cc:17205
+msgid ""
+"A function with the same name already exists.\n"
+"Do you want to overwrite the function?"
+msgstr ""
+"Una funció amb el mateix nom ja existeix.\n"
+"Voleu sobreescriure la funció?"
+
+#: ../src/callbacks.cc:15986 ../src/callbacks.cc:16001
+msgid "Unit does not exist"
+msgstr "La unitat no existeix"
+
+#: ../src/callbacks.cc:16031
+msgid "Edit Unknown Variable (global)"
+msgstr "Edita la variable desconeguda (global)"
+
+#: ../src/callbacks.cc:16033
+msgid "New Unknown Variable"
+msgstr "Variable desconeguda nova"
+
+#. unknown with the same name exists -- overwrite or open dialog again
+#. variable with the same name exists -- overwrite or open dialog again
+#: ../src/callbacks.cc:16104 ../src/callbacks.cc:16321
+#: ../src/callbacks.cc:16571 ../src/callbacks.cc:17313
+msgid ""
+"An unit or variable with the same name already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+"Una unitat o variable amb el mateix nom ja existeix.\n"
+"Voleu sobreescriure-la?"
+
+#: ../src/callbacks.cc:16215
+msgid "Edit Variable (global)"
+msgstr "Edita la variable (global)"
+
+#: ../src/callbacks.cc:16217
+msgid "New Variable"
+msgstr "Variable nova"
+
+#: ../src/callbacks.cc:16317
+msgid "Empty value field."
+msgstr "El camp de valor està buit."
+
+#: ../src/callbacks.cc:16418
+msgid "Edit Vector"
+msgstr "Edita el vector"
+
+#: ../src/callbacks.cc:16420
+msgid "Edit Vector (global)"
+msgstr "Edita el vector (global)"
+
+#: ../src/callbacks.cc:16422
+msgid "New Vector"
+msgstr "Vector nou"
+
+#: ../src/callbacks.cc:16429
+msgid "Edit Matrix (global)"
+msgstr "Edita la matriu (global)"
+
+#: ../src/callbacks.cc:16431
+msgid "New Matrix"
+msgstr "Matriu nova"
+
+#: ../src/callbacks.cc:16692
+msgid "Vector Result"
+msgstr "Resultat vector"
+
+#: ../src/callbacks.cc:16694
+msgid "Matrix Result"
+msgstr "Resultat de matriu"
+
+#: ../src/callbacks.cc:16849
+msgid "New Data Object"
+msgstr "Objecte de dades nou"
+
+#: ../src/callbacks.cc:16951
+msgid "text"
+msgstr "text"
+
+#: ../src/callbacks.cc:16956 ../src/callbacks.cc:16964
+msgid "approximate"
+msgstr "aproximat"
+
+#: ../src/callbacks.cc:17124
+msgid "Edit Data Set (global)"
+msgstr "Edita el conjunt de dades (global)"
+
+#: ../src/callbacks.cc:17126
+msgid "New Data Set"
+msgstr "Conjunt de dades nou"
+
+#: ../src/callbacks.cc:17143
+msgid "info"
+msgstr "info"
+
+#: ../src/callbacks.cc:17234
+msgid "Property"
+msgstr "Propietat"
+
+#: ../src/callbacks.cc:17301 ../src/callbacks.cc:17388
+msgid "No file name entered."
+msgstr "No s'ha introduït cap nom de fitxer."
+
+#: ../src/callbacks.cc:17343 ../src/callbacks.cc:17417
+msgid "No delimiter selected."
+msgstr "No s'ha seleccionat cap delimitador."
+
+#: ../src/callbacks.cc:17348
+#, c-format
+msgid ""
+"Could not import from file \n"
+"%s"
+msgstr ""
+"No s'ha pogut importar del fitxer \n"
+"%s"
+
+#: ../src/callbacks.cc:17430
+msgid "No variable name entered."
+msgstr "No s'ha introduït cap nom de variable."
+
+#: ../src/callbacks.cc:17442
+msgid "No known variable with entered name found."
+msgstr "No s'ha trobat cap variable coneguda amb el nom introduït."
+
+#: ../src/callbacks.cc:17449
+#, c-format
+msgid ""
+"Could not export to file \n"
+"%s"
+msgstr ""
+"No s'ha pogut exportar al fitxer \n"
+"%s"
+
+#: ../src/callbacks.cc:17550 ../src/callbacks.cc:17558
+#: ../src/callbacks.cc:23193 ../src/callbacks.cc:27701
+#: ../src/callbacks.cc:27704
+msgid "My Variables"
+msgstr "Les meves variables"
+
+#: ../src/callbacks.cc:18091
+msgid "Couldn't write definitions"
+msgstr "No s'ha pogut escriure les definicions"
+
+#: ../src/callbacks.cc:18169 ../src/callbacks.cc:19160
+msgid "Preset"
+msgstr "Preestablert"
+
+#: ../src/callbacks.cc:18408
+msgid "Abort"
+msgstr "Avorta"
+
+#: ../src/callbacks.cc:18411
+msgid "Undo"
+msgstr "Desfés"
+
+#: ../src/callbacks.cc:18414
+msgid "Redo"
+msgstr "Refés"
+
+#: ../src/callbacks.cc:18419
+msgid "Completion Mode"
+msgstr "Mode de compleció"
+
+#: ../src/callbacks.cc:18432
+msgid "Limited strict completion"
+msgstr "Compleció estricta limitada"
+
+#: ../src/callbacks.cc:18433
+msgid "Strict completion"
+msgstr "Compleció estricta"
+
+#: ../src/callbacks.cc:18434
+msgid "Limited full completion"
+msgstr "Compleció plena limitada"
+
+#: ../src/callbacks.cc:18435
+msgid "Full completion"
+msgstr "Compleció plena"
+
+#: ../src/callbacks.cc:18436
+msgid "No completion"
+msgstr "Cap compleció"
+
+#: ../src/callbacks.cc:18445
+msgid "Delayed completion"
+msgstr "Compleció retardada"
+
+#: ../src/callbacks.cc:18447
+msgid "Customize completion…"
+msgstr "Personalitza la compleció…"
+
+#: ../src/callbacks.cc:18933
+msgid "Save Mode"
+msgstr "Desa el mode"
+
+#: ../src/callbacks.cc:18961
+msgid "Preset mode cannot be overwritten."
+msgstr "No es pot sobreescriure el mode preestablert."
+
+#: ../src/callbacks.cc:18989
+msgid "Delete Mode"
+msgstr "Suprimeix el mode"
+
+#: ../src/callbacks.cc:20264
+#, c-format
+msgid ""
+"Couldn't write preferences to\n"
+"%s"
+msgstr ""
+"No s'ha pogut escriure les preferèncias a\n"
+"%s"
+
+#: ../src/callbacks.cc:21707 ../src/callbacks.cc:21720
+msgid "never"
+msgstr "mai"
+
+#: ../src/callbacks.cc:21708 ../src/callbacks.cc:21722
+msgid "ask"
+msgstr "pregunta"
+
+#: ../src/callbacks.cc:21716
+#, c-format
+msgid "%i day"
+msgid_plural "%i days"
+msgstr[0] "%i dia"
+msgstr[1] "%i dies"
+
+#. Result was copied
+#: ../src/callbacks.cc:23011
+msgid "Copied"
+msgstr "Copiat"
+
+#: ../src/callbacks.cc:25136
+msgid "log10 function not found."
+msgstr "No s'ha trobat la funció log10."
+
+#: ../src/callbacks.cc:26014
+msgid "Search"
+msgstr "Cerca"
+
+#: ../src/callbacks.cc:26014
+msgid "_Search"
+msgstr "_Cerca"
+
+#: ../src/callbacks.cc:26035 ../src/callbacks.cc:26287
+msgid "Remove Bookmark"
+msgstr "Elimina el marcador"
+
+#: ../src/callbacks.cc:26089
+msgid "Add Bookmark"
+msgstr "Afegeix un marcador"
+
+#: ../src/callbacks.cc:26115
+msgid ""
+"A bookmark with the selected name already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+"Un marcador amb el nom seleccionat ja existeix.\n"
+"Voleu sobreescriure'l?"
+
+#: ../src/callbacks.cc:26306
+msgid "No items found"
+msgstr "No s'ha trobat cap element"
+
+#: ../src/callbacks.cc:26567 ../src/callbacks.cc:33175
+msgid "Select date"
+msgstr "Selecció de data"
+
+#: ../src/callbacks.cc:27186
+msgid "Rectangular form"
+msgstr "Forma rectangular"
+
+#: ../src/callbacks.cc:27187
+msgid "Exponential form"
+msgstr "Forma exponencial"
+
+#: ../src/callbacks.cc:27188
+msgid "Polar form"
+msgstr "Forma polar"
+
+#: ../src/callbacks.cc:27189
+msgid "Angle/phasor notation"
+msgstr "Notació d'angle o de fasor"
+
+#: ../src/callbacks.cc:27207
+msgid "Optimal unit"
+msgstr "Unitat òptima"
+
+#: ../src/callbacks.cc:27208
+msgid "Optimal prefix"
+msgstr "Prefix òptim"
+
+#: ../src/callbacks.cc:27444
+msgid "All functions"
+msgstr "Totes les funcions"
+
+#: ../src/callbacks.cc:27496
+msgid "All variables"
+msgstr "Totes les variables"
+
+#: ../src/callbacks.cc:27801
+msgid "Select definitions file"
+msgstr "Selecció del fitxer de definicions"
+
+#: ../src/callbacks.cc:27801
+msgid "_Import"
+msgstr "_Importa"
+
+#: ../src/callbacks.cc:27821
+#, c-format
+msgid "Could not copy %s to %s."
+msgstr "No s'ha pogut copiar %s a %s."
+
+#: ../src/callbacks.cc:27829
+#, c-format
+msgid "Could not read %s."
+msgstr "No s'ha pogut llegir %s."
+
+#: ../src/callbacks.cc:27837
+#, c-format
+msgid "Could not copy file to %s."
+msgstr "No s'ha pogut copiar el fitxer a %s."
+
+#: ../src/callbacks.cc:28441 ../src/callbacks.cc:28521
+#: ../src/callbacks.cc:28601 ../src/callbacks.cc:28648
+#: ../src/callbacks.cc:33853 ../src/callbacks.cc:34053
+#: ../src/callbacks.cc:34209
+msgid "Unsupported base."
+msgstr "La base no és admesa."
+
+#: ../src/callbacks.cc:28847
+msgid "The selected Chinese year does not exist."
+msgstr "L'any xinés seleccionat no existeix."
+
+#: ../src/callbacks.cc:28859
+msgid "Conversion to Gregorian calendar failed."
+msgstr "La conversió al calendari gregorià ha fallat."
+
+#: ../src/callbacks.cc:28884
+#, c-format
+msgid "Calendar conversion failed for: %s."
+msgstr "La conversió de calendari ha fallat per a: %s."
+
+#: ../src/callbacks.cc:28919
+msgid "Gnuplot was not found."
+msgstr "No s'ha trobat el Gnuplot."
+
+#: ../src/callbacks.cc:28921
+#, c-format
+msgid ""
+"%s (%s) needs to be installed separately, and found in the executable search "
+"path, for plotting to work."
+msgstr ""
+"%s (%s) necessita instal·lar-se separadament, i trobar-se en el camí de "
+"cerca d'executables, per a que funcioni el dibuix."
+
+#: ../src/callbacks.cc:29511
+msgid "Select file to save PNG image to"
+msgstr "Selecció del fitxer al qual desar la imatge PNG"
+
+#: ../src/callbacks.cc:29515 ../src/callbacks.cc:34408
+msgid "Allowed File Types"
+msgstr "Tipus de fitxer permesos"
+
+#: ../src/callbacks.cc:29520 ../src/callbacks.cc:34419
+msgid "All Files"
+msgstr "Tots els fitxers"
+
+#. do not delete units that are used by other units
+#: ../src/callbacks.cc:30093
+msgid "Cannot delete unit as it is needed by other units."
+msgstr "No es pot suprimir la unitat perquè altres unitats la necessiten."
+
+#: ../src/callbacks.cc:30548 ../src/callbacks.cc:30777
+msgid "none"
+msgstr "cap"
+
+#: ../src/callbacks.cc:31048 ../src/callbacks.cc:31049
+#: ../src/callbacks.cc:31050 ../src/callbacks.cc:31051
+#: ../src/callbacks.cc:31063
+msgid "result is too long"
+msgstr "el resultat és massa llarg"
+
+#: ../src/callbacks.cc:31885 ../src/callbacks.cc:31886
+msgid "translator-credits"
+msgstr "Alex Henrie <alexhenrie24@gmail.com>"
+
+#: ../src/callbacks.cc:32288 ../src/callbacks.cc:33842
+#: ../src/callbacks.cc:34042 ../src/callbacks.cc:34198
+msgid "Mode not found."
+msgstr "No s'ha trobat el mode."
+
+#: ../src/callbacks.cc:33094 ../src/callbacks.cc:33102
+#: ../src/callbacks.cc:33110 ../src/callbacks.cc:33118
+msgid "Elements (in horizontal order)"
+msgstr "Elements (en ordre horitzontal)"
+
+#: ../src/callbacks.cc:33131 ../src/callbacks.cc:33219
+msgid "Select file to import"
+msgstr "Selecció del fitxer a importar"
+
+#: ../src/callbacks.cc:33131 ../src/callbacks.cc:33157
+#: ../src/callbacks.cc:33219
+msgid "_Open"
+msgstr "_Obre"
+
+#: ../src/callbacks.cc:33157
+msgid "Select file to export to"
+msgstr "Selecció del fitxer al qual exportar"
+
+#: ../src/callbacks.cc:33529 ../src/callbacks.cc:33559
+msgid ""
+"A conflicting object with the same name exists. If you proceed and save "
+"changes, the conflicting object will be overwritten or deactivated.\n"
+"Do you want to proceed?"
+msgstr ""
+"Un objecte conflictiu amb el mateix nom existeix. Si procediu i deseu els "
+"canvis, l'objecte conflictiu se sobreescriurà o es desactivarà.\n"
+"Voleu procedir?"
+
+#: ../src/callbacks.cc:33742
+msgid "Set key combination"
+msgstr "Establiment de combinació de tecles"
+
+#. Make the line reasonably long, but not to short (at least around 40 characters)
+#: ../src/callbacks.cc:33746
+msgid ""
+"Press the key combination you wish to use for the action\n"
+"(press Escape to cancel)."
+msgstr ""
+"Premeu la combinació de tecles que voleu usar per l'acció\n"
+"(premeu Escapa per a cancel·lar.)"
+
+#: ../src/callbacks.cc:33756
+msgid "No keys"
+msgstr "Sense claus"
+
+#: ../src/callbacks.cc:33802 ../src/callbacks.cc:34002
+#: ../src/callbacks.cc:34158
+msgid "Empty value."
+msgstr "El valor està buit."
+
+#: ../src/callbacks.cc:33812 ../src/callbacks.cc:34012
+#: ../src/callbacks.cc:34168
+msgid "Function not found."
+msgstr "No s'ha trobat la funció."
+
+#: ../src/callbacks.cc:33820 ../src/callbacks.cc:34020
+#: ../src/callbacks.cc:34176
+msgid "Variable not found."
+msgstr "No s'ha trobat la variable."
+
+#: ../src/callbacks.cc:33828 ../src/callbacks.cc:34028
+#: ../src/callbacks.cc:34184
+msgid "Unit not found."
+msgstr "No s'ha trobat la unitat."
+
+#: ../src/callbacks.cc:33869 ../src/callbacks.cc:33928
+msgid ""
+"The key combination is already in use.\n"
+"Do you wish to replace the current action?"
+msgstr ""
+"La combinació de tecles ja està en ús.\n"
+"Voleu reemplaçar l'acció actual?"
+
+#: ../src/callbacks.cc:34404
+msgid "Select file to export"
+msgstr "Selecció del fitxer a exportar"
+
+#: ../src/callbacks.cc:34521 ../src/callbacks.cc:34566
+msgid "Empty expression."
+msgstr "L'expressió està buida."
+
+#: ../src/callbacks.cc:34535 ../src/callbacks.cc:34580
+msgid "Empty x variable."
+msgstr "La variable x està buida."
+
+#: ../src/callbacks.cc:34775
+msgid "Element Data"
+msgstr "Dades d'element"
+
+#: ../src/callbacks.cc:34813
+msgid "Classification"
+msgstr "Classificació"
+
+#: ../src/callbacks.cc:34818
+msgid "Alkali Metal"
+msgstr "Metall alcalí"
+
+#: ../src/callbacks.cc:34819
+msgid "Alkaline-Earth Metal"
+msgstr "Metall alcalinoterri"
+
+#: ../src/callbacks.cc:34820
+msgid "Lanthanide"
+msgstr "Lantanoide"
+
+#: ../src/callbacks.cc:34821
+msgid "Actinide"
+msgstr "Actinoide"
+
+#: ../src/callbacks.cc:34822
+msgid "Transition Metal"
+msgstr "Metall de transició"
+
+#: ../src/callbacks.cc:34823
+msgid "Metal"
+msgstr "Metall"
+
+#: ../src/callbacks.cc:34824
+msgid "Metalloid"
+msgstr "Metal·loide"
+
+#: ../src/callbacks.cc:34825
+msgid "Polyatomic Non-Metal"
+msgstr "Poliatòmic no metal"
+
+#: ../src/callbacks.cc:34826
+msgid "Diatomic Non-Metal"
+msgstr "Diatòmic no metal"
+
+#: ../src/callbacks.cc:34827
+msgid "Noble Gas"
+msgstr "Gas noble"
+
+#: ../src/callbacks.cc:34828
+msgid "Unknown chemical properties"
+msgstr "Propietats químiques desconegudes"
+
+#: ../src/callbacks.cc:34924
+msgid "No unknowns in result."
+msgstr "No hi ha cap desconeguda en el resultat."
+
+#: ../src/callbacks.cc:34930
+msgid "Set Unknowns"
+msgstr "Estableix les desconegudes"
+
+#: ../src/searchprovider.cc:244
+msgid "Copy result to clipboard"
+msgstr "Copia el resultat al porta-retalls"

--- a/po/qalculate-gtk.pot
+++ b/po/qalculate-gtk.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-06-05 11:17+0200\n"
+"POT-Creation-Date: 2021-06-10 22:38-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1323,7 +1323,8 @@ msgstr ""
 
 #: ../data/main.ui.h:124
 msgid ""
-"Enables automatic use of hekto, deka, deci and centi when prefixes is enabled"
+"Enables automatic use of hekto, deka, deci and centi when prefixes are "
+"enabled"
 msgstr ""
 
 #: ../data/main.ui.h:125
@@ -1765,7 +1766,7 @@ msgstr ""
 
 #: ../data/main.ui.h:242
 msgid ""
-"If unit expression does not contain any prefixes, use optimal prefix. \n"
+"If unit expression does not contain any prefixes, use optimal prefix.\n"
 "\n"
 "This can be overridden by prepending the unit expression with \"?\" or \"0\"."
 msgstr ""
@@ -2640,7 +2641,7 @@ msgstr ""
 #: ../data/preferences.ui.h:9
 msgid ""
 "Allow multiple instances of the Qalculate! main window to be open at the "
-"same time. \n"
+"same time.\n"
 "\n"
 "Note that only the mode, history and definitions of the last closed instance "
 "will be saved."
@@ -2870,7 +2871,7 @@ msgstr ""
 #: ../data/preferences.ui.h:64
 msgid ""
 "Use 'j' (instead of 'i') as default symbol for the imaginary unit, and place "
-"it in front the imaginary part."
+"it in front of the imaginary part."
 msgstr ""
 
 #: ../data/preferences.ui.h:65
@@ -2889,7 +2890,7 @@ msgstr ""
 
 #: ../data/preferences.ui.h:68
 msgid ""
-"Allow commas, ',',  to be used as thousands separator instead of as an "
+"Allow commas, ',', to be used as thousands separator instead of as an "
 "function argument separator"
 msgstr ""
 
@@ -2898,172 +2899,178 @@ msgid "Ignore dots in numbers"
 msgstr ""
 
 #: ../data/preferences.ui.h:70
-msgid "Digit grouping"
+msgid ""
+"Allow dots, '.', to be used as thousands separator instead of as an "
+"alternative decimal sign"
 msgstr ""
 
 #: ../data/preferences.ui.h:71
-msgid "off"
+msgid "Digit grouping"
 msgstr ""
 
 #: ../data/preferences.ui.h:72
-msgid "standard"
+msgid "off"
 msgstr ""
 
 #: ../data/preferences.ui.h:73
-msgid "local"
+msgid "standard"
 msgstr ""
 
 #: ../data/preferences.ui.h:74
-msgid "Multiplication sign"
+msgid "local"
 msgstr ""
 
 #: ../data/preferences.ui.h:75
-msgid "Division sign"
+msgid "Multiplication sign"
 msgstr ""
 
 #: ../data/preferences.ui.h:76
-msgid "Copy digit separator"
+msgid "Division sign"
 msgstr ""
 
 #: ../data/preferences.ui.h:77
-msgid "Deactivate to remove digit separator when copying result"
+msgid "Copy digit separator"
 msgstr ""
 
 #: ../data/preferences.ui.h:78
-msgid "Numbers & Operators"
+msgid "Deactivate to remove digit separator when copying result"
 msgstr ""
 
 #: ../data/preferences.ui.h:79
-msgid "Use binary prefixes for information units"
+msgid "Numbers & Operators"
 msgstr ""
 
 #: ../data/preferences.ui.h:80
+msgid "Use binary prefixes for information units"
+msgstr ""
+
+#: ../data/preferences.ui.h:81
 msgid ""
 "Use binary, instead of decimal, prefixes by default for information units (e."
 "g. bytes)."
 msgstr ""
 
-#: ../data/preferences.ui.h:81
+#: ../data/preferences.ui.h:82
 msgid "Conversion to local currency"
 msgstr ""
 
-#: ../data/preferences.ui.h:82
+#: ../data/preferences.ui.h:83
 msgid ""
 "Automatically convert to the local currency when optimal unit conversion is "
 "activated."
 msgstr ""
 
-#: ../data/preferences.ui.h:83
+#: ../data/preferences.ui.h:84
 msgid "Update exchange rates on start"
 msgstr ""
 
-#: ../data/preferences.ui.h:84
+#: ../data/preferences.ui.h:85
 msgid ""
 "If current exchange rates shall be downloaded from the internet at program "
 "start"
 msgstr ""
 
-#: ../data/preferences.ui.h:85
+#: ../data/preferences.ui.h:86
 msgid "Exchange rates updates"
 msgstr ""
 
-#: ../data/preferences.ui.h:86
+#: ../data/preferences.ui.h:87
 msgid "Temperature calculation mode:"
 msgstr ""
 
-#: ../data/preferences.ui.h:87 ../src/callbacks.cc:2698
+#: ../data/preferences.ui.h:88 ../src/callbacks.cc:2698
 msgid "Absolute"
 msgstr ""
 
-#: ../data/preferences.ui.h:88 ../src/callbacks.cc:2705
+#: ../data/preferences.ui.h:89 ../src/callbacks.cc:2705
 msgid "Relative"
 msgstr ""
 
-#: ../data/preferences.ui.h:89 ../src/callbacks.cc:2712
+#: ../data/preferences.ui.h:90 ../src/callbacks.cc:2712
 msgid "Hybrid"
 msgstr ""
 
-#: ../data/preferences.ui.h:90
+#: ../data/preferences.ui.h:91
 msgid "Units & Currencies"
 msgstr ""
 
-#: ../data/preferences.ui.h:91
+#: ../data/preferences.ui.h:92
 msgid "Show expression completion suggestions"
 msgstr ""
 
-#: ../data/preferences.ui.h:92
+#: ../data/preferences.ui.h:93
 msgid "Search titles and countries"
 msgstr ""
 
-#: ../data/preferences.ui.h:93
+#: ../data/preferences.ui.h:94
 msgid "Minimum characters"
 msgstr ""
 
-#: ../data/preferences.ui.h:94
+#: ../data/preferences.ui.h:95
 msgid "Popup delay (ms)"
 msgstr ""
 
-#: ../data/preferences.ui.h:95
+#: ../data/preferences.ui.h:96
 msgid "Completion"
 msgstr ""
 
-#: ../data/preferences.ui.h:96
+#: ../data/preferences.ui.h:97
 msgid "Status warning color"
 msgstr ""
 
-#: ../data/preferences.ui.h:97
+#: ../data/preferences.ui.h:98
 msgid "Status error color"
 msgstr ""
 
-#: ../data/preferences.ui.h:98
+#: ../data/preferences.ui.h:99
 msgid "Custom status font"
 msgstr ""
 
-#: ../data/preferences.ui.h:99
+#: ../data/preferences.ui.h:100
 msgid ""
 "If you want to use a font other than the default in the status display below "
 "the expression entry"
 msgstr ""
 
-#: ../data/preferences.ui.h:100
+#: ../data/preferences.ui.h:101
 msgid "Custom expression font"
 msgstr ""
 
-#: ../data/preferences.ui.h:101
+#: ../data/preferences.ui.h:102
 msgid ""
 "If you want to use a font other than the default in the expression entry"
 msgstr ""
 
-#: ../data/preferences.ui.h:102
+#: ../data/preferences.ui.h:103
 msgid "Custom result font"
 msgstr ""
 
-#: ../data/preferences.ui.h:103
+#: ../data/preferences.ui.h:104
 msgid "If you want to use a font other than the default in the result display"
 msgstr ""
 
-#: ../data/preferences.ui.h:104
+#: ../data/preferences.ui.h:105
 msgid "Custom keypad font"
 msgstr ""
 
-#: ../data/preferences.ui.h:105
+#: ../data/preferences.ui.h:106
 msgid "If you want to use a font other than the default in the keypad"
 msgstr ""
 
-#: ../data/preferences.ui.h:106
+#: ../data/preferences.ui.h:107
 msgid "Custom application font"
 msgstr ""
 
-#: ../data/preferences.ui.h:107
+#: ../data/preferences.ui.h:108
 msgid ""
 "If you want to use a font other than the default for the whole application"
 msgstr ""
 
-#: ../data/preferences.ui.h:108
+#: ../data/preferences.ui.h:109
 msgid "Text color"
 msgstr ""
 
-#: ../data/preferences.ui.h:109
+#: ../data/preferences.ui.h:110
 msgid "Fonts & Colors"
 msgstr ""
 
@@ -3192,7 +3199,7 @@ msgstr ""
 #: ../data/unitedit.ui.h:27
 msgid ""
 "Unit (for named derived unit) or unit expression (for unnamed derived unit) "
-"that this unit as defined in relation to"
+"that this unit is defined in relation to"
 msgstr ""
 
 #: ../data/unitedit.ui.h:28
@@ -3485,7 +3492,7 @@ msgid ""
 "(variables, functions, etc.), mode, preferences, and history of the last "
 "closed window will be saved.\n"
 "\n"
-"Do you, despite this, want to change the default bahvior and allow multiple "
+"Do you, despite this, want to change the default behavior and allow multiple "
 "simultaneous instances?"
 msgstr ""
 
@@ -3898,7 +3905,7 @@ msgstr ""
 msgid ""
 "A new version of %s is available at %s.\n"
 "\n"
-"Do you wish to update to version %s."
+"Do you wish to update to version %s?"
 msgstr ""
 
 #: ../src/callbacks.cc:2452


### PR DESCRIPTION
I left the boolean operators "and" and "or" untranslated because "and" is "i" in Catalan and I didn't want there to be any confusion with the imaginary unit i.