### PR TITLE
Do not rewrite -Os to -O2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,21 +29,6 @@ dnl  ------------------------------------
 dnl | check for compiler characteristics |-------------------------------------
 dnl  ------------------------------------
 
-dnl Replace -Os with -O2 to stop segfault on startup
-if test "x$GCC" = "xyes"; then
-	case $CFLAGS in
-	*-Os*)
-		CFLAGS="$CFLAGS -O2"
-		;;
-	esac
-	case $CXXFLAGS in
-	*-Os*)
-		CXXFLAGS="$CXXFLAGS -O2"
-		;;
-	esac
-fi
-
-
 dnl Use -Wall if we have gcc.
 changequote(,)dnl
 if test "x$GCC" = "xyes"; then


### PR DESCRIPTION
It doesn't segfault when compiled with -Os (gcc 11.2.1), and if it does, that means you have an undefined behaviour here which may result in security vulnerability.

See also https://github.com/Qalculate/libqalculate/pull/386