### PR TITLE
Install search provider to libexecdir instead of libdir

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,7 +12,7 @@ AM_CPPFLAGS = \
 	@QALCULATE_CFLAGS@
 
 if ENABLE_SEARCH_PROVIDER
-searchproviderdir=@libdir@
+searchproviderdir=@libexecdir@
 searchprovider_PROGRAMS = qalculate-search-provider
 endif
 bin_PROGRAMS = @QALCULATE_GTK@
@@ -70,7 +70,7 @@ dbusservice_DATA = io.github.Qalculate.SearchProvider.service
 io.github.Qalculate.SearchProvider.service: Makefile
 	$(AM_V_GEN) (echo '[D-BUS Service]'; \
 		echo 'Name=io.github.Qalculate.SearchProvider'; \
-		echo 'Exec=@libdir@/qalculate-search-provider') > $@.tmp && \
+		echo 'Exec=@libexecdir@/qalculate-search-provider') > $@.tmp && \
 		mv $@.tmp $@
 
 endif


### PR DESCRIPTION
See https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch04s07.html and https://www.gnu.org/prep/standards/html_node/Directory-Variables.html