### PR TITLE
Add Portuguese (Portugal) translation

### DIFF
--- a/po/pt_PT.po
+++ b/po/pt_PT.po
@@ -1,0 +1,5641 @@
+# Portuguese (Portugal) translations for Qalculate! package.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the qalculate-gtk package.
+# Hugo Carvalho <hugokarvalho@hotmail.com>, 2024.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-02-22 09:08+0100\n"
+"PO-Revision-Date: 2024-04-17 17:23+0100\n"
+"Last-Translator: Hugo Carvalho <hugokarvalho@hotmail.com>\n"
+"Language-Team: \n"
+"Language: pt_PT\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.4.2\n"
+
+#: ../data/qalculate-gtk.desktop.in.h:1 ../src/callbacks.cc:12032
+#: ../src/callbacks.cc:12039
+msgid "Qalculate!"
+msgstr "Qalculate!"
+
+#: ../data/qalculate-gtk.desktop.in.h:2
+msgid "Calculator"
+msgstr "Calculadora"
+
+#: ../data/qalculate-gtk.desktop.in.h:3
+#: ../data/qalculate-gtk.appdata.xml.in.h:2 ../src/callbacks.cc:34888
+msgid "Powerful and easy to use calculator"
+msgstr "Calculadora potente e fácil de usar"
+
+#: ../data/qalculate-gtk.desktop.in.h:4
+msgid "calculation;arithmetic;scientific;financial;"
+msgstr "calculadora;aritmética;científica;financeira;"
+
+#: ../data/qalculate-gtk.appdata.xml.in.h:1
+msgid "Qalculate! (GTK UI)"
+msgstr "Qalculate! (GTK UI)"
+
+#: ../data/qalculate-gtk.appdata.xml.in.h:3
+msgid ""
+"Qalculate! is a multi-purpose cross-platform desktop calculator. It is "
+"simple to use but provides power and versatility normally reserved for "
+"complicated math packages, as well as useful tools for everyday needs (such "
+"as currency conversion and percent calculation)."
+msgstr ""
+"Qalculate! é uma calculadora multiplataforma e multiuso. É simples de usar, "
+"mas fornece poder e versatilidade normalmente vistas em pacotes de "
+"matemática complicados, além de ferramentas úteis para as necessidades "
+"diárias (como conversão de moeda e cálculo de percentagem)."
+
+#: ../data/qalculate-gtk.appdata.xml.in.h:4
+msgid ""
+"Features include a large library of customizable functions, unit "
+"calculations and conversion, physical constants, symbolic calculations "
+"(including integrals and equations), arbitrary precision, uncertainty "
+"propagation, interval arithmetic, plotting, and a user-friendly interface."
+msgstr ""
+"Os recursos incluem uma grande biblioteca de funções personalizáveis, "
+"cálculos e conversão de unidades, constantes físicas, cálculos simbólicos "
+"(incluindo integrais e equações), precisão arbitrária, propagação de erros, "
+"aritmética de intervalos, parcela e uma interface amigável."
+
+#: ../data/argumentrules.ui.h:1 ../data/functionedit.ui.h:24
+msgid "Argument Rules"
+msgstr "Regras de argumento"
+
+#: ../data/argumentrules.ui.h:2 ../data/buttonsedit.ui.h:9
+#: ../data/csvexport.ui.h:2 ../data/csvimport.ui.h:2 ../data/datasetedit.ui.h:2
+#: ../data/datasets.ui.h:2 ../data/functionedit.ui.h:3 ../data/matrix.ui.h:2
+#: ../data/matrixedit.ui.h:3 ../data/shortcuts.ui.h:7 ../data/unitedit.ui.h:3
+#: ../data/unknownedit.ui.h:3 ../data/variableedit.ui.h:3
+#: ../src/callbacks.cc:2829 ../src/callbacks.cc:18652 ../src/callbacks.cc:19682
+#: ../src/callbacks.cc:19801 ../src/callbacks.cc:21012
+#: ../src/callbacks.cc:21068 ../src/callbacks.cc:28783
+#: ../src/callbacks.cc:29387 ../src/callbacks.cc:30421
+#: ../src/callbacks.cc:30423 ../src/callbacks.cc:32378
+#: ../src/callbacks.cc:32380 ../src/callbacks.cc:36291
+#: ../src/callbacks.cc:36293 ../src/callbacks.cc:36329
+#: ../src/callbacks.cc:36331 ../src/callbacks.cc:36358
+#: ../src/callbacks.cc:36401 ../src/callbacks.cc:36403
+#: ../src/callbacks.cc:37752 ../src/callbacks.cc:37754
+#: ../src/callbacks.cc:38397
+msgid "_Cancel"
+msgstr "_Cancelar"
+
+#: ../data/argumentrules.ui.h:3 ../data/functionedit.ui.h:25
+msgid "Do not save modifications"
+msgstr "Não gravar modificações"
+
+#: ../data/argumentrules.ui.h:4 ../data/buttonsedit.ui.h:10
+#: ../data/csvexport.ui.h:3 ../data/csvimport.ui.h:4 ../data/datasetedit.ui.h:3
+#: ../data/datasets.ui.h:4 ../data/functionedit.ui.h:4
+#: ../data/matrixedit.ui.h:4 ../data/shortcuts.ui.h:9 ../data/unitedit.ui.h:5
+#: ../data/unknownedit.ui.h:4 ../data/variableedit.ui.h:4
+#: ../src/callbacks.cc:2829 ../src/callbacks.cc:3078 ../src/callbacks.cc:3156
+#: ../src/callbacks.cc:3209 ../src/callbacks.cc:3278 ../src/callbacks.cc:19682
+#: ../src/callbacks.cc:19801 ../src/callbacks.cc:28783
+#: ../src/callbacks.cc:29387 ../src/callbacks.cc:36358
+#: ../src/callbacks.cc:38397
+msgid "_OK"
+msgstr "_OK"
+
+#: ../data/argumentrules.ui.h:5
+msgid "Accept the modification of argument rules"
+msgstr "Aceitar modificação de regras de argumento"
+
+#: ../data/argumentrules.ui.h:6 ../data/buttonsedit.ui.h:12
+#: ../data/shortcuts.ui.h:11
+msgid "Argument name"
+msgstr "Nome do argumento"
+
+#: ../data/argumentrules.ui.h:7
+msgid "Free"
+msgstr "Livre"
+
+#: ../data/argumentrules.ui.h:8 ../data/datasetedit.ui.h:15 ../data/main.ui.h:7
+#: ../data/unknownedit.ui.h:9
+msgid "Number"
+msgstr "Número"
+
+#: ../data/argumentrules.ui.h:9 ../data/main.ui.h:11
+#: ../data/unknownedit.ui.h:12
+msgid "Integer"
+msgstr "Inteiro"
+
+#: ../data/argumentrules.ui.h:10
+msgid "Symbol"
+msgstr "Símbolo"
+
+#: ../data/argumentrules.ui.h:11 ../data/datasetedit.ui.h:14
+msgid "Text"
+msgstr "Texto"
+
+#: ../data/argumentrules.ui.h:12
+msgid "Date"
+msgstr "Data"
+
+#: ../data/argumentrules.ui.h:13 ../data/main.ui.h:22 ../data/matrix.ui.h:10
+#: ../data/matrixedit.ui.h:13 ../src/callbacks.cc:18655
+msgid "Vector"
+msgstr "Vetor"
+
+#: ../data/argumentrules.ui.h:14 ../data/csvimport.ui.h:13 ../data/main.ui.h:21
+#: ../data/matrix.ui.h:1 ../data/matrixedit.ui.h:11 ../src/callbacks.cc:18657
+msgid "Matrix"
+msgstr "Matriz"
+
+#: ../data/argumentrules.ui.h:15
+msgid "Positive number"
+msgstr "Número positivo"
+
+#: ../data/argumentrules.ui.h:16
+msgid "Non-zero number"
+msgstr "Número diferente de zero"
+
+#: ../data/argumentrules.ui.h:17
+msgid "Non-negative number"
+msgstr "Número não-negativo"
+
+#: ../data/argumentrules.ui.h:18
+msgid "Positive integer"
+msgstr "Número inteiro positivo"
+
+#: ../data/argumentrules.ui.h:19
+msgid "Non-zero integer"
+msgstr "Inteiro diferente de zero"
+
+#: ../data/argumentrules.ui.h:20
+msgid "Non-negative integer"
+msgstr "Inteiro não-negativo"
+
+#: ../data/argumentrules.ui.h:21 ../data/main.ui.h:12
+#: ../data/unknownedit.ui.h:13
+msgid "Boolean"
+msgstr "Boleano"
+
+#: ../data/argumentrules.ui.h:22 ../src/callbacks.cc:19207
+msgid "Object"
+msgstr "Objeto"
+
+#: ../data/argumentrules.ui.h:23 ../data/datasetedit.ui.h:35
+#: ../data/main.ui.h:24 ../data/plot.ui.h:9 ../src/interface.cc:2685
+msgid "Function"
+msgstr "Função"
+
+#: ../data/argumentrules.ui.h:24 ../data/main.ui.h:26
+msgid "Unit"
+msgstr "Unidade"
+
+#: ../data/argumentrules.ui.h:25 ../data/main.ui.h:20 ../src/interface.cc:2743
+msgid "Variable"
+msgstr "Variável"
+
+#: ../data/argumentrules.ui.h:26 ../data/csvexport.ui.h:12
+#: ../data/csvimport.ui.h:6
+msgid "File"
+msgstr "Ficheiro"
+
+#: ../data/argumentrules.ui.h:27
+msgid "Angle"
+msgstr "Ângulo"
+
+#: ../data/argumentrules.ui.h:28 ../src/callbacks.cc:26066
+msgid "Data object"
+msgstr "Onjeto de dados"
+
+#: ../data/argumentrules.ui.h:29
+msgid "Data property"
+msgstr "Propriedade de dados"
+
+#: ../data/argumentrules.ui.h:30
+msgid "Enable rules and type test"
+msgstr "Ativar regras e teste de tipo"
+
+#: ../data/argumentrules.ui.h:31
+msgid "Custom condition"
+msgstr "Condição personalizada"
+
+#: ../data/argumentrules.ui.h:32
+msgid ""
+"For example if argument is a matrix that must have equal number of rows and "
+"columns: rows(\\x) = columns(\\x)"
+msgstr ""
+"Por exemplo, se o argumento for uma matriz que deve ter igual número de "
+"linhas e colunas:  rows(\\x) = columns(\\x)"
+
+#: ../data/argumentrules.ui.h:33
+msgid "Allow matrix"
+msgstr "Permitir matriz"
+
+#: ../data/argumentrules.ui.h:34
+msgid "Forbid zero"
+msgstr "Proibir zero"
+
+#: ../data/argumentrules.ui.h:35
+msgid "Handle vector"
+msgstr "Trabalhar com vetor"
+
+#: ../data/argumentrules.ui.h:36
+msgid "Calculate function for each separate element in vector."
+msgstr "Calcular a função para cada elemento separado no vetor."
+
+#: ../data/argumentrules.ui.h:37
+msgid "Min"
+msgstr "Mín"
+
+#: ../data/argumentrules.ui.h:38
+msgid "Include equals"
+msgstr "Incluir iguais"
+
+#: ../data/argumentrules.ui.h:39
+msgid "Max"
+msgstr "Máx"
+
+#: ../data/argumentrules.ui.h:40 ../data/unknownedit.ui.h:7
+#: ../src/interface.cc:3259 ../src/interface.cc:3493
+msgid "Type"
+msgstr "Tipo"
+
+#: ../data/argumentrules.ui.h:41 ../data/csvimport.ui.h:8
+#: ../data/datasetedit.ui.h:4 ../data/functionedit.ui.h:5
+#: ../data/matrixedit.ui.h:6 ../data/unitedit.ui.h:7 ../data/unknownedit.ui.h:5
+#: ../data/variableedit.ui.h:5 ../src/interface.cc:2586
+#: ../src/interface.cc:2819 ../src/interface.cc:3253 ../src/interface.cc:3490
+#: ../src/interface.cc:3534 ../src/callbacks.cc:21019 ../src/callbacks.cc:28790
+msgid "Name"
+msgstr "Nome"
+
+#: ../data/buttonsedit.ui.h:1 ../data/main.ui.h:65
+msgid "Customize Keypad Buttons"
+msgstr "Personalizar botões do teclado"
+
+#: ../data/buttonsedit.ui.h:2 ../data/calendarconversion.ui.h:2
+#: ../data/datasets.ui.h:7 ../data/decimals.ui.h:2 ../data/floatingpoint.ui.h:2
+#: ../data/functions.ui.h:2 ../data/namesedit.ui.h:2 ../data/nbases.ui.h:2
+#: ../data/percentage.ui.h:5 ../data/plot.ui.h:5 ../data/precision.ui.h:2
+#: ../data/preferences.ui.h:2 ../data/setbase.ui.h:2 ../data/shortcuts.ui.h:2
+#: ../data/units.ui.h:2 ../data/variables.ui.h:2 ../src/callbacks.cc:2831
+#: ../src/callbacks.cc:16420 ../src/callbacks.cc:18644
+#: ../src/callbacks.cc:28709 ../src/callbacks.cc:38210
+msgid "_Close"
+msgstr "_Fechar"
+
+#: ../data/buttonsedit.ui.h:3 ../src/interface.cc:4547
+msgid "Label"
+msgstr "Etiqueta"
+
+#: ../data/buttonsedit.ui.h:4 ../src/interface.cc:4550
+msgid "Left-click"
+msgstr "Botão esquerdo"
+
+#: ../data/buttonsedit.ui.h:5 ../src/interface.cc:4553
+msgid "Right-click"
+msgstr "Botão direito"
+
+#: ../data/buttonsedit.ui.h:6 ../src/interface.cc:4556
+msgid "Middle-click"
+msgstr "Botão do meio"
+
+#: ../data/buttonsedit.ui.h:7
+msgid "Reset"
+msgstr "Redefinir"
+
+#: ../data/buttonsedit.ui.h:8
+msgid "Button Action"
+msgstr "Ação do Botão"
+
+#: ../data/buttonsedit.ui.h:11 ../data/floatingpoint.ui.h:3
+#: ../data/shortcuts.ui.h:10 ../data/variableedit.ui.h:7
+#: ../src/interface.cc:2495 ../src/interface.cc:4367 ../src/callbacks.cc:16484
+msgid "Value"
+msgstr "Valor"
+
+#: ../data/calendarconversion.ui.h:1 ../data/main.ui.h:39
+msgid "Calendar Conversion"
+msgstr "Conversão de calendário"
+
+#: ../data/csvexport.ui.h:1
+msgid "Export CSV File"
+msgstr "Exportar ficheiro CSV"
+
+#: ../data/csvexport.ui.h:4
+msgid "Current result"
+msgstr "Resultado atual"
+
+#: ../data/csvexport.ui.h:5
+msgid "Matrix/vector variable"
+msgstr "Variável matriz/vetor"
+
+#: ../data/csvexport.ui.h:6 ../data/csvimport.ui.h:20
+msgid "Delimiter"
+msgstr "Delimitador"
+
+#: ../data/csvexport.ui.h:7 ../data/csvimport.ui.h:24
+msgid "Comma"
+msgstr "Vírgula"
+
+#: ../data/csvexport.ui.h:8 ../data/csvimport.ui.h:25
+msgid "Tabulator"
+msgstr "Tabulador"
+
+#: ../data/csvexport.ui.h:9 ../data/csvimport.ui.h:26
+msgid "Semicolon"
+msgstr "Ponto-e-vírgula"
+
+#: ../data/csvexport.ui.h:10 ../data/csvimport.ui.h:27
+msgid "Space"
+msgstr "Espaço"
+
+#: ../data/csvexport.ui.h:11 ../data/csvimport.ui.h:28
+msgid "Other"
+msgstr "Outro"
+
+#: ../data/csvimport.ui.h:1
+msgid "Import CSV File"
+msgstr "Importar ficheiro CSV"
+
+#: ../data/csvimport.ui.h:3
+msgid "Do not import the file"
+msgstr "Não importar o ficheiro"
+
+#: ../data/csvimport.ui.h:5
+msgid "Import the file"
+msgstr "Importar o ficheiro"
+
+#: ../data/csvimport.ui.h:7
+msgid "Import as"
+msgstr "Importar como"
+
+#: ../data/csvimport.ui.h:9 ../data/datasetedit.ui.h:5
+#: ../data/functionedit.ui.h:19 ../data/matrixedit.ui.h:19
+#: ../data/unitedit.ui.h:9 ../data/variableedit.ui.h:13
+msgid "Descriptive name"
+msgstr "Nome descritivo"
+
+#: ../data/csvimport.ui.h:10 ../data/functionedit.ui.h:18 ../data/main.ui.h:252
+#: ../data/matrixedit.ui.h:18 ../data/unitedit.ui.h:8
+#: ../data/variableedit.ui.h:11 ../src/interface.cc:2597
+#: ../src/interface.cc:2699 ../src/interface.cc:2757 ../src/interface.cc:2833
+msgid "Category"
+msgstr "Categoria"
+
+#: ../data/csvimport.ui.h:11
+msgid "First row"
+msgstr "Primeira linha"
+
+#: ../data/csvimport.ui.h:12
+msgid "Name of the data file to import"
+msgstr "Nome do ficheiro de dados a ser importado"
+
+#: ../data/csvimport.ui.h:14
+msgid "If a matrix shall be generated from the contents of the file"
+msgstr ""
+"Se uma matriz ou vetores devem ser gerados a partir do conteúdo do ficheiro"
+
+#: ../data/csvimport.ui.h:15
+msgid "Vectors"
+msgstr "Vetores"
+
+#: ../data/csvimport.ui.h:16
+msgid "If vectors shall be generated from the contents of the file"
+msgstr ""
+"Se uma matriz ou vetores devem ser gerados a partir do conteúdo do ficheiro"
+
+#: ../data/csvimport.ui.h:17
+msgid ""
+"Name (or name prefix) used to reference generated variable(s) in expressions"
+msgstr ""
+"Nome (ou prefixo do nome) usado para referenciar variáveis geradas em "
+"expressões"
+
+#: ../data/csvimport.ui.h:18 ../data/matrixedit.ui.h:20
+#: ../data/variableedit.ui.h:12
+msgid "Title displayed in menus and in variable manager"
+msgstr "Título exibido nos menus e no gestor de variáveis"
+
+#: ../data/csvimport.ui.h:19
+msgid "The first row with data to import in the file"
+msgstr "A primeira linha com dados a serem importados no ficheiro"
+
+#: ../data/csvimport.ui.h:21
+msgid "Includes headings"
+msgstr "Incluir cabeçalhos"
+
+#: ../data/csvimport.ui.h:22
+msgid "If the first row contains column headings"
+msgstr "Se a primeira linha deve conter cabeçalhos de coluna"
+
+#: ../data/csvimport.ui.h:23
+msgid "Delimiter used to separate columns in the file"
+msgstr "Delimitador usado para separar colunas no ficheiro"
+
+#: ../data/csvimport.ui.h:29
+msgid "Custom delimiter"
+msgstr "Delimitador personalizado"
+
+#: ../data/datasetedit.ui.h:1
+msgid "Edit Data Property"
+msgstr "Editar propriedades de dados"
+
+#: ../data/datasetedit.ui.h:6 ../data/functionedit.ui.h:22
+#: ../data/matrixedit.ui.h:21 ../data/unitedit.ui.h:11
+#: ../data/variableedit.ui.h:14
+msgid "Description"
+msgstr "Descrição"
+
+#: ../data/datasetedit.ui.h:7
+msgid "Value Type"
+msgstr "Tipo de valor"
+
+#: ../data/datasetedit.ui.h:8
+msgid "Use as key"
+msgstr "Usar como chave"
+
+#: ../data/datasetedit.ui.h:9
+msgid "Case sensitive value"
+msgstr "Valor sensível a maiúsculas e minúsculas"
+
+#: ../data/datasetedit.ui.h:10
+msgid "Approximate value"
+msgstr "Valor aproximado"
+
+#: ../data/datasetedit.ui.h:11
+msgid "Value uses brackets"
+msgstr "Valor usa parênteses"
+
+#: ../data/datasetedit.ui.h:12
+msgid "Hide"
+msgstr "Ocultar"
+
+#: ../data/datasetedit.ui.h:13 ../data/main.ui.h:250
+msgid "Unit expression"
+msgstr "Expressão de unidade"
+
+#: ../data/datasetedit.ui.h:16 ../data/functionedit.ui.h:8 ../data/plot.ui.h:8
+#: ../src/interface.cc:3279 ../src/interface.cc:4230
+msgid "Expression"
+msgstr "Expressão"
+
+#: ../data/datasetedit.ui.h:17
+msgid "Name used for reference"
+msgstr "Nome usado para referência"
+
+#: ../data/datasetedit.ui.h:18
+msgid "Title displayed in menus and in data set manager"
+msgstr "Título exibido nos menus e no gestor de conjunto de dados"
+
+#: ../data/datasetedit.ui.h:19
+msgid "Description of this data property"
+msgstr "Descrição desta propriedade de dados"
+
+#: ../data/datasetedit.ui.h:20 ../src/callbacks.cc:19092
+msgid "Edit Data Set"
+msgstr "Editar conjunto de dados"
+
+#: ../data/datasetedit.ui.h:21
+msgid "Data file"
+msgstr "Ficheiro de dados"
+
+#: ../data/datasetedit.ui.h:22
+msgid "Copyright"
+msgstr "Direitos autorais"
+
+#: ../data/datasetedit.ui.h:23
+msgid "Description of this data set"
+msgstr "Descrição deste conjunto de dados"
+
+#: ../data/datasetedit.ui.h:24 ../data/unitedit.ui.h:17
+msgid "General"
+msgstr "Geral"
+
+#: ../data/datasetedit.ui.h:25
+msgid "Properties:"
+msgstr "Propriedades:"
+
+#: ../data/datasetedit.ui.h:26
+msgid "Definition of the properties of this data set"
+msgstr "Definição das propriedades deste conjunto de dados"
+
+#: ../data/datasetedit.ui.h:27 ../data/functions.ui.h:6 ../data/main.ui.h:19
+#: ../data/units.ui.h:11 ../data/variables.ui.h:6
+msgid "_New"
+msgstr "_Novo"
+
+#: ../data/datasetedit.ui.h:28 ../data/functionedit.ui.h:14
+#: ../data/functions.ui.h:8 ../data/main.ui.h:44 ../data/namesedit.ui.h:4
+#: ../data/shortcuts.ui.h:4 ../data/units.ui.h:13 ../data/variables.ui.h:8
+msgid "_Edit"
+msgstr "_Editar"
+
+#: ../data/datasetedit.ui.h:29 ../data/functions.ui.h:10 ../data/units.ui.h:15
+#: ../data/variables.ui.h:10 ../src/callbacks.cc:21068
+msgid "_Delete"
+msgstr "_Eliminar"
+
+#: ../data/datasetedit.ui.h:30 ../src/callbacks.cc:5577
+#: ../src/callbacks.cc:6646
+msgid "Properties"
+msgstr "Propriedades"
+
+#: ../data/datasetedit.ui.h:31
+msgid "Object argument name"
+msgstr "Nome do argumento do objeto"
+
+#: ../data/datasetedit.ui.h:32
+msgid "Property argument name"
+msgstr "Nome do argumento da propriedade"
+
+#: ../data/datasetedit.ui.h:33
+msgid "Default property"
+msgstr "Propriedade padrão"
+
+#: ../data/datasetedit.ui.h:34
+msgid "Name used to invoke the function in expressions"
+msgstr "Nome usado para chamar a função em expressões"
+
+#: ../data/datasets.ui.h:1 ../src/callbacks.cc:18809
+msgid "Edit Data Object"
+msgstr "Editar Objeto de Dados"
+
+#: ../data/datasets.ui.h:3
+msgid "Do not create/modify this data object"
+msgstr "Não criar/modificar este objeto de dados"
+
+#: ../data/datasets.ui.h:5
+msgid "Accept the creation/modification of this data object"
+msgstr "Aceitar a criação/modificação deste objeto de dados"
+
+#: ../data/datasets.ui.h:6 ../data/main.ui.h:48 ../src/callbacks.cc:19199
+msgid "Data Sets"
+msgstr "Conjuntos de dados"
+
+#: ../data/datasets.ui.h:8 ../data/main.ui.h:25 ../src/interface.cc:2934
+msgid "Data Set"
+msgstr "Conjunto de dados"
+
+#: ../data/datasets.ui.h:9
+msgid "Create a new data set"
+msgstr "Criar um novo conjunto de dados"
+
+#: ../data/datasets.ui.h:10
+msgid "Edit the selected data set"
+msgstr "Editar o conjunto de dados selecionado"
+
+#: ../data/datasets.ui.h:11
+msgid "Delete the selected data set"
+msgstr "Eliminar o conjunto de dados selecionado"
+
+#: ../data/datasets.ui.h:12
+msgid "Objects"
+msgstr "Objetos"
+
+#: ../data/datasets.ui.h:13
+msgid "Create a new data object"
+msgstr "Criar um novo objeto de dados"
+
+#: ../data/datasets.ui.h:14
+msgid "Edit the selected data object"
+msgstr "Editar o objeto de dados selecionado"
+
+#: ../data/datasets.ui.h:15
+msgid "Remove the selected data object"
+msgstr "Remover o objeto de dados selecionados"
+
+#: ../data/datasets.ui.h:16
+msgid "Data Set Description"
+msgstr "Descrição do conjunto de dados"
+
+#: ../data/datasets.ui.h:17
+msgid "Object Attributes"
+msgstr "Atributos do objeto"
+
+#: ../data/decimals.ui.h:1
+msgid "Decimals"
+msgstr "Decimais"
+
+#: ../data/decimals.ui.h:3 ../data/matrix.ui.h:3 ../data/plot.ui.h:6
+#: ../data/precision.ui.h:3
+msgid "Close this window"
+msgstr "Fechar esta janela"
+
+#: ../data/decimals.ui.h:4
+msgid "Min decimals"
+msgstr "Decimais mínimos"
+
+#: ../data/decimals.ui.h:5
+msgid "Max decimals"
+msgstr "Decimais máximos"
+
+#: ../data/decimals.ui.h:6
+msgid "Minimal number of displayed decimals"
+msgstr "Número mínimo de casas decimais exibidas"
+
+#: ../data/decimals.ui.h:7
+msgid "Maximal number of decimals to display (and round to)"
+msgstr "Número máximo de casas decimais a serem exibidas (e arredondadas)"
+
+#: ../data/floatingpoint.ui.h:1
+msgid "Floating Point Conversion"
+msgstr "Conversão de ponto flutuante"
+
+#: ../data/floatingpoint.ui.h:4
+msgid "Hexadecimal representation"
+msgstr "Representação hexadecimal"
+
+#: ../data/floatingpoint.ui.h:5
+msgid "Conversion error"
+msgstr "Erro de conversão"
+
+#: ../data/floatingpoint.ui.h:6
+msgid "Binary representation"
+msgstr "Representação binária"
+
+#: ../data/floatingpoint.ui.h:7
+msgid "Floating point value"
+msgstr "Valor do ponto flutuante"
+
+#: ../data/floatingpoint.ui.h:8
+msgid "Format"
+msgstr "Formato"
+
+#: ../data/floatingpoint.ui.h:9
+msgid "16-bit (half precision)"
+msgstr "16-bits (precisão média)"
+
+#: ../data/floatingpoint.ui.h:10
+msgid "32-bit (single precision)"
+msgstr "32-bits (precisão única)"
+
+#: ../data/floatingpoint.ui.h:11
+msgid "64-bit (double precision)"
+msgstr "64-bits (precisão dupla)"
+
+#: ../data/floatingpoint.ui.h:12
+msgid "80-bit (x86 extended format)"
+msgstr "80-bits (formato estendido x86)"
+
+#: ../data/floatingpoint.ui.h:13
+msgid "128-bit (quadruple precision)"
+msgstr "128-bits (precisão quádrupla)"
+
+#: ../data/floatingpoint.ui.h:14
+msgid "Microchip 24-bit"
+msgstr "Microchip 24-bits"
+
+#: ../data/floatingpoint.ui.h:15
+msgid "Microchip 32-bit"
+msgstr "Microchip 32-bits"
+
+#: ../data/functionedit.ui.h:1 ../src/callbacks.cc:17620
+msgid "Edit Function"
+msgstr "Editar Função"
+
+#: ../data/functionedit.ui.h:2 ../data/main.ui.h:211 ../data/matrixedit.ui.h:2
+#: ../data/plot.ui.h:2 ../data/unitedit.ui.h:2 ../data/unknownedit.ui.h:2
+#: ../data/variableedit.ui.h:2
+msgid "_Help"
+msgstr "_Ajuda"
+
+#: ../data/functionedit.ui.h:6
+msgid "Name used to invoke this function in expressions"
+msgstr "Nome usado para chamar esta função em expressões"
+
+#: ../data/functionedit.ui.h:7
+msgid ""
+"Use \\x for the first, \\y for the second and \\z for the third argument. "
+"For more information click the help button."
+msgstr ""
+"Use \\x para o primeiro, \\y para o segundo e \\z para o terceiro argumento. "
+"Para mais informações, clique no botão de ajuda."
+
+#: ../data/functionedit.ui.h:9 ../data/matrixedit.ui.h:16
+#: ../data/variableedit.ui.h:9
+msgid "Required"
+msgstr "Obrigatório"
+
+#: ../data/functionedit.ui.h:10
+msgid "Condition"
+msgstr "Condição"
+
+#: ../data/functionedit.ui.h:11
+msgid ""
+"Condition that must be true for the function (e.g. if the second argument "
+"must be greater than the first: \"\\y > \\x\")"
+msgstr ""
+"Condição que deve ser verdadeira para a função (por exemplo, se o segundo "
+"argumento deve ser maior que o primeiro: \"\\y > \\x\")"
+
+#: ../data/functionedit.ui.h:12
+msgid "Sub-functions"
+msgstr "Subfunções"
+
+#: ../data/functionedit.ui.h:13 ../data/namesedit.ui.h:3 ../data/plot.ui.h:35
+#: ../data/shortcuts.ui.h:3
+msgid "_Add"
+msgstr "_Adicionar"
+
+#: ../data/functionedit.ui.h:15 ../data/namesedit.ui.h:5 ../data/plot.ui.h:37
+#: ../data/shortcuts.ui.h:5
+msgid "_Remove"
+msgstr "_Remover"
+
+#: ../data/functionedit.ui.h:16 ../src/callbacks.cc:5518
+msgid "Arguments"
+msgstr "Argumentos"
+
+#: ../data/functionedit.ui.h:17
+msgid "Details"
+msgstr "Detalhes"
+
+#: ../data/functionedit.ui.h:20
+msgid "Title displayed in menus and in function manager"
+msgstr "Título exibido nos menus e no gestor de funções"
+
+#: ../data/functionedit.ui.h:21
+msgid "Hide function"
+msgstr "Ocultar função"
+
+#: ../data/functionedit.ui.h:23
+msgid "Example"
+msgstr "Exemplo"
+
+#: ../data/functionedit.ui.h:26 ../src/interface.cc:3284
+msgid "Precalculate"
+msgstr "Pré-calcular"
+
+#: ../data/functionedit.ui.h:27
+msgid "If this function shall be hidden in menus"
+msgstr "Caso a função esteja oculta nos menus"
+
+#: ../data/functions.ui.h:1 ../data/main.ui.h:46
+msgid "Functions"
+msgstr "Funções"
+
+#: ../data/functions.ui.h:3 ../data/units.ui.h:8 ../data/variables.ui.h:3
+msgid "Categor_y"
+msgstr "Categor_ia"
+
+#: ../data/functions.ui.h:4
+msgid "_Function"
+msgstr "_Função"
+
+#: ../data/functions.ui.h:5 ../data/units.ui.h:10 ../data/variables.ui.h:5
+msgid "Descri_ption"
+msgstr "Desc_rição"
+
+#: ../data/functions.ui.h:7 ../data/main.ui.h:278
+msgid "Create a new function"
+msgstr "Criar uma nova função"
+
+#: ../data/functions.ui.h:9
+msgid "Edit the selected function"
+msgstr "Editar a função selecionada"
+
+#: ../data/functions.ui.h:11
+msgid "Delete the selected function"
+msgstr "Eliminar a função selecionada"
+
+#: ../data/functions.ui.h:12
+msgid "(De)activate the selected function"
+msgstr "Desativar a função selecionada"
+
+#: ../data/functions.ui.h:13 ../data/units.ui.h:18 ../data/variables.ui.h:13
+#: ../src/callbacks.cc:5617 ../src/callbacks.cc:5900 ../src/callbacks.cc:6209
+#: ../src/callbacks.cc:19988
+msgid "Deacti_vate"
+msgstr "Desati_var"
+
+#: ../data/functions.ui.h:14
+msgid "_Calculate"
+msgstr "_Calcular"
+
+#: ../data/functions.ui.h:15
+msgid "Insert (or execute) the selected function into the expression entry"
+msgstr "Inserir (ou executar) a função selecionada na entrada da expressão"
+
+#: ../data/functions.ui.h:16 ../data/plot.ui.h:36 ../src/callbacks.cc:38397
+msgid "_Apply"
+msgstr "_Aplicar"
+
+#: ../data/functions.ui.h:17
+msgid "Apply the selected function to the current expression"
+msgstr "Aplicar função selecionada à expressão atual"
+
+#: ../data/main.ui.h:1
+msgid "Degrees"
+msgstr "Graus"
+
+#: ../data/main.ui.h:2
+msgid "Radians"
+msgstr "Radianos"
+
+#: ../data/main.ui.h:3
+msgid "Gradians"
+msgstr "Grados"
+
+#: ../data/main.ui.h:4 ../src/callbacks.cc:5886
+msgid "Default assumptions"
+msgstr "Suposições padrão"
+
+#: ../data/main.ui.h:5 ../data/unknownedit.ui.h:14 ../src/callbacks.cc:38267
+msgid "Unknown"
+msgstr "Desconhecido"
+
+#: ../data/main.ui.h:6
+msgid "Not Matrix"
+msgstr "Não-matriz"
+
+#: ../data/main.ui.h:8
+msgid "Complex"
+msgstr "Complexo"
+
+#: ../data/main.ui.h:9
+msgid "Real"
+msgstr "Real"
+
+#: ../data/main.ui.h:10
+msgid "Rational"
+msgstr "Racional"
+
+#: ../data/main.ui.h:13 ../data/unknownedit.ui.h:19
+msgid "Non-Zero"
+msgstr "Diferente de zero"
+
+#: ../data/main.ui.h:14 ../data/unknownedit.ui.h:15
+msgid "Positive"
+msgstr "Positivo"
+
+#: ../data/main.ui.h:15 ../data/unknownedit.ui.h:16
+msgid "Non-Negative"
+msgstr "Não-negativo"
+
+#: ../data/main.ui.h:16 ../data/unknownedit.ui.h:17
+msgid "Negative"
+msgstr "Negativo"
+
+#: ../data/main.ui.h:17 ../data/unknownedit.ui.h:18
+msgid "Non-Positive"
+msgstr "Não-positivo"
+
+#: ../data/main.ui.h:18
+msgid "_File"
+msgstr "_Ficheiro"
+
+#: ../data/main.ui.h:23
+msgid "Unknown Variable"
+msgstr "Variável desconhecida"
+
+#: ../data/main.ui.h:27
+msgid "Import CSV File…"
+msgstr "Importar ficheiro CSV…"
+
+#: ../data/main.ui.h:28
+msgid "Export CSV File…"
+msgstr "Exportar ficheiro CSV…"
+
+#: ../data/main.ui.h:29
+msgid "_Store Result…"
+msgstr "_Guardar resultado…"
+
+#: ../data/main.ui.h:30
+msgid "Save Result Image…"
+msgstr "Gravar imagem do resultado…"
+
+#: ../data/main.ui.h:31
+msgid "Save local functions, variables and units"
+msgstr "Gravar funções, variáveis e unidades"
+
+#: ../data/main.ui.h:32
+msgid "Save Definitions"
+msgstr "Gravar definições"
+
+#: ../data/main.ui.h:33
+msgid "Import Definitions File…"
+msgstr "Importar ficheiro de definições…"
+
+#: ../data/main.ui.h:34
+msgid "Fetch current exchange rates from the Internet"
+msgstr "Buscar taxas de câmbio atualizadas na Internet"
+
+#: ../data/main.ui.h:35
+msgid "Update Exchange Rates"
+msgstr "Atualizar taxas de câmbio"
+
+#: ../data/main.ui.h:36
+msgid "Plot Functions/Data"
+msgstr "Funções/dados de parcela"
+
+#: ../data/main.ui.h:37
+msgid "Convert Number Bases"
+msgstr "Converter bases numéricas"
+
+#: ../data/main.ui.h:38
+msgid "Floating Point Conversion (IEEE 754)"
+msgstr "Conversão de ponto flutuante (IEEE 754)"
+
+#: ../data/main.ui.h:40
+msgid "Percentage Calculation Tool"
+msgstr "Ferramenta de cálculo de percentagem"
+
+#: ../data/main.ui.h:41 ../data/periodictable.ui.h:1
+msgid "Periodic Table"
+msgstr "Tabela Periódica"
+
+#: ../data/main.ui.h:42
+msgid "Minimal Window"
+msgstr "Janela mínima"
+
+#: ../data/main.ui.h:43
+msgid "_Quit"
+msgstr "_Sair"
+
+#: ../data/main.ui.h:45 ../data/variables.ui.h:1
+msgid "Variables"
+msgstr "Variáveis"
+
+#: ../data/main.ui.h:47 ../data/units.ui.h:1
+msgid "Units"
+msgstr "Unidades"
+
+#: ../data/main.ui.h:49 ../src/interface.cc:1576 ../src/callbacks.cc:2026
+#: ../src/callbacks.cc:30286
+msgid "Factorize"
+msgstr "Fatorar"
+
+#: ../data/main.ui.h:50 ../src/interface.cc:1574 ../src/callbacks.cc:2029
+#: ../src/callbacks.cc:30300
+msgid "Expand"
+msgstr "Expandir"
+
+#: ../data/main.ui.h:51
+msgid "Apply partial fraction decomposition to the current result."
+msgstr "Aplicar decomposição de fração parcial ao resultado atual."
+
+#: ../data/main.ui.h:52 ../src/interface.cc:1578
+msgid "Expand Partial Fractions"
+msgstr "Expandir Frações Parciais"
+
+#: ../data/main.ui.h:53
+msgid "Set Unknowns…"
+msgstr "Definir Incógnitos…"
+
+#: ../data/main.ui.h:54
+msgid "Convert to Unit"
+msgstr "Converter em Unidade"
+
+#: ../data/main.ui.h:55
+msgid "Set Prefix"
+msgstr "Definir Prefixo"
+
+#: ../data/main.ui.h:56
+msgid "Convert to Unit Expression…"
+msgstr "Converter em Expressão de Unidade…"
+
+#: ../data/main.ui.h:57
+msgid "Convert to Base Units"
+msgstr "Converter em Unidades Base"
+
+#: ../data/main.ui.h:58
+msgid "Convert to Optimal Unit"
+msgstr "Converter em Unidade Ideal"
+
+#: ../data/main.ui.h:59 ../src/callbacks.cc:20564
+msgid "Insert Date…"
+msgstr "Inserir Data…"
+
+#: ../data/main.ui.h:60 ../src/callbacks.cc:20565
+msgid "Insert Matrix…"
+msgstr "Inserir Matriz…"
+
+#: ../data/main.ui.h:61 ../src/callbacks.cc:20566
+msgid "Insert Vector…"
+msgstr "Inserir Vetor…"
+
+#: ../data/main.ui.h:62
+msgid "_Copy Result"
+msgstr "_Copiar resultado"
+
+#: ../data/main.ui.h:63
+msgid "Copy Result as Unformatted ASCII"
+msgstr "Copiar resultado como ASCII não formatado"
+
+#: ../data/main.ui.h:64 ../data/shortcuts.ui.h:1
+msgid "Keyboard Shortcuts"
+msgstr "Atalhos do teclado"
+
+#: ../data/main.ui.h:66
+msgid "_Preferences"
+msgstr "_Preferências"
+
+#: ../data/main.ui.h:67
+msgid "_Mode"
+msgstr "_Modo"
+
+#: ../data/main.ui.h:68 ../src/callbacks.cc:8347 ../src/callbacks.cc:20538
+msgid "Number Base"
+msgstr "Base numérica"
+
+#: ../data/main.ui.h:69
+msgid "Select Result and Expression Base…"
+msgstr "Selecionar resultado e base de expressão…"
+
+#: ../data/main.ui.h:70 ../data/nbases.ui.h:4 ../data/setbase.ui.h:3
+#: ../src/interface.cc:1773 ../src/callbacks.cc:20541 ../src/callbacks.cc:34034
+#: ../src/callbacks.cc:34076
+msgid "Binary"
+msgstr "Binário"
+
+#: ../data/main.ui.h:71 ../data/nbases.ui.h:5 ../data/setbase.ui.h:4
+#: ../src/interface.cc:1774 ../src/callbacks.cc:20542 ../src/callbacks.cc:34035
+#: ../src/callbacks.cc:34077
+msgid "Octal"
+msgstr "Octal"
+
+#: ../data/main.ui.h:72 ../data/nbases.ui.h:3 ../data/setbase.ui.h:5
+#: ../src/interface.cc:1775 ../src/callbacks.cc:20543 ../src/callbacks.cc:34036
+#: ../src/callbacks.cc:34078
+msgid "Decimal"
+msgstr "Decimal"
+
+#: ../data/main.ui.h:73 ../data/nbases.ui.h:10 ../data/setbase.ui.h:6
+#: ../src/callbacks.cc:20544 ../src/callbacks.cc:34037
+#: ../src/callbacks.cc:34079
+msgid "Duodecimal"
+msgstr "Duodecimal"
+
+#: ../data/main.ui.h:74 ../data/nbases.ui.h:11 ../data/setbase.ui.h:7
+#: ../src/interface.cc:1776 ../src/callbacks.cc:20545 ../src/callbacks.cc:34038
+#: ../src/callbacks.cc:34080
+msgid "Hexadecimal"
+msgstr "Hexadecimal"
+
+#: ../data/main.ui.h:75 ../src/callbacks.cc:20547
+msgid "Other…"
+msgstr "Outro…"
+
+#: ../data/main.ui.h:76 ../data/setbase.ui.h:8
+msgid "Sexagesimal"
+msgstr "Sexagesimal"
+
+#: ../data/main.ui.h:77 ../src/callbacks.cc:8406
+msgid "Time Format"
+msgstr "Formato da hora"
+
+#: ../data/main.ui.h:78 ../src/callbacks.cc:8402 ../src/callbacks.cc:20546
+msgid "Roman Numerals"
+msgstr "Números romanos"
+
+#: ../data/main.ui.h:79
+msgid "Numerical Display"
+msgstr "Exibição numérica"
+
+#: ../data/main.ui.h:80
+msgid "Normal"
+msgstr "Normal"
+
+#: ../data/main.ui.h:81
+msgid "Engineering"
+msgstr "Engenharia"
+
+#: ../data/main.ui.h:82
+msgid "Scientific"
+msgstr "Científica"
+
+#: ../data/main.ui.h:83
+msgid "Purely Scientific"
+msgstr "Puramente Científica"
+
+#: ../data/main.ui.h:84
+msgid "Simple"
+msgstr "Simples"
+
+#: ../data/main.ui.h:85
+msgid ""
+"Off: 1/7 ≈ 0.14285714\n"
+"On: 1/7 = 0.142857 142857..."
+msgstr ""
+"Desativado: 1/7 ≈ 0,14285714\n"
+"Ativado: 1/7 = 0,142857 142857..."
+
+#: ../data/main.ui.h:87
+msgid "Indicate Repeating Decimals"
+msgstr "Indicar decimais repetidos"
+
+#: ../data/main.ui.h:88
+msgid "Show Ending Zeroes"
+msgstr "Mostrar zeros finais"
+
+#: ../data/main.ui.h:89
+msgid ""
+"Off: -x + y\n"
+"On: y - x"
+msgstr ""
+"Desativado: -x + y\n"
+"Ativado: y - x"
+
+#: ../data/main.ui.h:91
+msgid "Sort Minus Last"
+msgstr "Classificar menos último"
+
+#: ../data/main.ui.h:92
+msgid "Round Halfway Numbers Away from Zero"
+msgstr "Arredondar números intermédios longe de zero"
+
+#: ../data/main.ui.h:93
+msgid "Round Halfway Numbers to Even"
+msgstr "Arredondar números até a metade"
+
+#: ../data/main.ui.h:94
+msgid "Other Rounding Methods"
+msgstr "Outros métodos de arredondamento"
+
+#: ../data/main.ui.h:95
+msgid "Round Halfway Numbers to Odd"
+msgstr "Arredondar números intermédios para ímpares"
+
+#: ../data/main.ui.h:96
+msgid "Round Halfway Numbers Toward Zero"
+msgstr "Arredondar números intermédios em direção a zero"
+
+#: ../data/main.ui.h:97
+msgid "Round Halfway Numbers to Random"
+msgstr "Arredondar números intermédios para aleatórios"
+
+#: ../data/main.ui.h:98
+msgid "Round Halfway Numbers Up"
+msgstr "Arredondar números intermédios para cima"
+
+#: ../data/main.ui.h:99
+msgid "Round Halfway Numbers Down"
+msgstr "Arredondar números intermédios para baixo"
+
+#: ../data/main.ui.h:100
+msgid "Round Toward Zero"
+msgstr "Arredondar para zero"
+
+#: ../data/main.ui.h:101
+msgid "Round Away from Zero"
+msgstr "Arredondar para longe do zero"
+
+#: ../data/main.ui.h:102
+msgid "Round Up"
+msgstr "Arredondar para cima"
+
+#: ../data/main.ui.h:103
+msgid "Round Down"
+msgstr "Arredondar para baixo"
+
+#: ../data/main.ui.h:104 ../src/callbacks.cc:8400
+msgid "Complex Rectangular Form"
+msgstr "Forma retangular complexa"
+
+#: ../data/main.ui.h:105 ../src/callbacks.cc:8362
+msgid "Complex Exponential Form"
+msgstr "Forma exponencial complexa"
+
+#: ../data/main.ui.h:106 ../src/callbacks.cc:8396
+msgid "Complex Polar Form"
+msgstr "Forma polar complexa"
+
+#: ../data/main.ui.h:107 ../src/callbacks.cc:8341
+msgid "Complex Angle/Phasor Notation"
+msgstr "Notação complexa de ângulo/fasor"
+
+#: ../data/main.ui.h:108
+msgid "Rational Number Form"
+msgstr "Forma do número racional"
+
+#: ../data/main.ui.h:109
+msgid "1/3 ≈ 0.33333"
+msgstr "1/3 ≈ 0,33333"
+
+#: ../data/main.ui.h:110
+msgid "Decimal Fractions"
+msgstr "Frações decimais"
+
+#: ../data/main.ui.h:111
+msgid ""
+"3/9 = 1/3\n"
+"6/4 = 1.5"
+msgstr ""
+"3/9 = 1/3\n"
+"6/4 = 1,5"
+
+#: ../data/main.ui.h:113
+msgid "Exact Decimal Fractions"
+msgstr "Frações decimais exatas"
+
+#: ../data/main.ui.h:114
+msgid "6/4 = 3/2"
+msgstr "6/4 = 3/2"
+
+#: ../data/main.ui.h:115
+msgid "Simple Fractions"
+msgstr "Frações simples"
+
+#: ../data/main.ui.h:116
+msgid "6/4 = 1+1/2"
+msgstr "6/4 = 1+1/2"
+
+#: ../data/main.ui.h:117
+msgid "Mixed Fractions"
+msgstr "Frações mistas"
+
+#. Mixed fraction
+#: ../data/main.ui.h:119
+msgid "Mixed"
+msgstr "Mistas"
+
+#: ../data/main.ui.h:120
+msgid "Interval Display"
+msgstr "Visualização de intervalo"
+
+#: ../data/main.ui.h:121
+msgid ""
+"Off: 1/2 × pi ≈ 1.5707963\n"
+"On: 1/2 × pi = 0.5 pi"
+msgstr ""
+"Desativado: 1/2 × pi ≈ 1,5707963\n"
+"Ativado: 1/2 × pi = 0,5 pi"
+
+#: ../data/main.ui.h:123 ../src/callbacks.cc:3307
+msgid "Adaptive"
+msgstr "Adaptativa"
+
+#: ../data/main.ui.h:124
+msgid ""
+"Calculates an interval of possible values and keeps track of precision "
+"changes."
+msgstr ""
+"Calcula um intervalo de valores possíveis e acompanha mudanças de precisão."
+
+#: ../data/main.ui.h:125
+msgid "Significant Digits"
+msgstr "Dígitos significativos"
+
+#: ../data/main.ui.h:126 ../src/interface.cc:1219 ../src/interface.cc:4479
+msgid "Interval"
+msgstr "Intervalo"
+
+#: ../data/main.ui.h:127
+msgid "Plus/Minus"
+msgstr "Mais/Menos"
+
+#: ../data/main.ui.h:128 ../data/preferences.ui.h:100 ../src/callbacks.cc:3098
+msgid "Relative"
+msgstr "Relativo"
+
+#: ../data/main.ui.h:129
+msgid "Concise"
+msgstr "Conciso"
+
+#: ../data/main.ui.h:130
+msgid "Midpoint"
+msgstr "Ponto médio"
+
+#: ../data/main.ui.h:131
+msgid "Allow concise uncertainty input"
+msgstr "Permitir a introdução concisa de incertezas"
+
+#: ../data/main.ui.h:132
+msgid "Unit Display"
+msgstr "Visualização de unidade"
+
+#: ../data/main.ui.h:133
+msgid "Do not use any prefixes in result"
+msgstr "Não usar nenhum prefixo no resultado"
+
+#: ../data/main.ui.h:134
+msgid "Show prefixes for primarily SI and CGS units."
+msgstr "Mostrar prefixos principalmente para unidades SI e CGS."
+
+#: ../data/main.ui.h:135
+msgid "Use prefixes for selected units"
+msgstr "Usar prefixos para unidades selecionadas"
+
+#: ../data/main.ui.h:136
+msgid "Use prefixes also for currencies"
+msgstr "Usar prefixos também para moedas"
+
+#: ../data/main.ui.h:137
+msgid "Use prefixs for all units"
+msgstr "Usar prefixos em todas as unidades"
+
+#: ../data/main.ui.h:138
+msgid ""
+"Enables automatic use of hekto, deka, deci and centi when prefixes are "
+"enabled"
+msgstr ""
+"Permite o uso automático de hekto, deka, deci e centi quando os prefixos "
+"estão ativados"
+
+#: ../data/main.ui.h:139
+msgid "Enable All SI Prefixes"
+msgstr "Ativar Todos os Prefixos SI"
+
+#: ../data/main.ui.h:140
+msgid ""
+"Enables automatic setting of prefix for denominator in addition to the "
+"numerator"
+msgstr ""
+"Ativar a configuração automática de prefixo para o denominador, além do "
+"numerador"
+
+#: ../data/main.ui.h:141
+msgid "Enable Denominator Prefixes"
+msgstr "Ativar Prefixos de Denominador"
+
+#: ../data/main.ui.h:142
+msgid ""
+"Off: J / K\n"
+"On: J·K^-1"
+msgstr ""
+"Desativado: J / K\n"
+"Ativado: J·K^-1"
+
+#: ../data/main.ui.h:144
+msgid "Negative Exponents"
+msgstr "Expoentes negativos"
+
+#: ../data/main.ui.h:145
+msgid ""
+"Off: (2 m)/s\n"
+"On: 2 (m/s)"
+msgstr ""
+"Desativado: (2 m)/s\n"
+"Ativado: 2 (m/s)"
+
+#: ../data/main.ui.h:147
+msgid "Place Units Separately"
+msgstr "Colocar unidades separadamente"
+
+#: ../data/main.ui.h:148
+msgid "No Additional Conversion"
+msgstr "Nenhuma conversão adicional"
+
+#: ../data/main.ui.h:149
+msgid "Convert to Optimal SI Unit"
+msgstr "Converter em unidade SI ideal"
+
+#: ../data/main.ui.h:150
+msgid ""
+"If enabled:\n"
+"15 in = 1 ft + 3 in\n"
+"3.2 h = 3 h + 12 min"
+msgstr ""
+"Se ativado:\n"
+"15 in = 1 ft + 3 in\n"
+"3,2 h = 3 h + 12 min"
+
+#: ../data/main.ui.h:153
+msgid "Convert to Mixed Units"
+msgstr "Converter em unidades mistas"
+
+#: ../data/main.ui.h:154
+msgid "Abbreviate Names"
+msgstr "Abreviar nomes"
+
+#: ../data/main.ui.h:155
+msgid "Enabled Objects"
+msgstr "Objetos ativados"
+
+#: ../data/main.ui.h:156
+msgid "Unknowns"
+msgstr "Desconhecidos"
+
+#: ../data/main.ui.h:157
+msgid "Units in Physical Constants"
+msgstr "Unidades em constantes físicas"
+
+#: ../data/main.ui.h:158
+msgid "If not enabled, treats all variables as unknown"
+msgstr "Se não estiver ativado, trata todas as variáveis como desconhecidas"
+
+#: ../data/main.ui.h:159
+msgid "Calculate Variables"
+msgstr "Calcular variáveis"
+
+#: ../data/main.ui.h:160
+msgid "Disables/enables complex numbers in result"
+msgstr "Desativar/ativar números complexos no resultado"
+
+#: ../data/main.ui.h:161
+msgid "Allow Complex Result"
+msgstr "Permitir resultado complexo"
+
+#: ../data/main.ui.h:162
+msgid "Disables/enables infinite numbers in result"
+msgstr "Desativar/ativar números infinitos no resultado"
+
+#: ../data/main.ui.h:163
+msgid "Allow Infinite Result"
+msgstr "Permitir resultado infinito"
+
+#: ../data/main.ui.h:164
+msgid "Approximation"
+msgstr "Aproximação"
+
+#: ../data/main.ui.h:165
+msgid "Always Exact"
+msgstr "Sempre exato"
+
+#: ../data/main.ui.h:166
+msgid "Try Exact"
+msgstr "Tentar exato"
+
+#: ../data/main.ui.h:167 ../src/callbacks.cc:18857
+msgid "Approximate"
+msgstr "Aproximado"
+
+#: ../data/main.ui.h:168
+msgid "Interval Arithmetic"
+msgstr "Aritmética de intervalo"
+
+#: ../data/main.ui.h:169
+msgid "Interval Calculation"
+msgstr "Cálculo de intervalo"
+
+#: ../data/main.ui.h:170
+msgid "Variance Formula"
+msgstr "Fórmula de variância"
+
+#: ../data/main.ui.h:171
+msgid "Change angle unit used in trigonometric functions"
+msgstr "Alterar unidade de ângulo usada em funções trigonométricas"
+
+#: ../data/main.ui.h:172
+msgid "Angle Unit"
+msgstr "Unidade de ângulo"
+
+#: ../data/main.ui.h:173 ../data/plot.ui.h:27 ../src/interface.cc:4590
+msgid "None"
+msgstr "Nenhum"
+
+#: ../data/main.ui.h:174
+msgid "Assumptions"
+msgstr "Suposições"
+
+#: ../data/main.ui.h:175
+msgid "Algebraic Mode"
+msgstr "Modo Algébrico"
+
+#: ../data/main.ui.h:176
+msgid "Assume that unknown denominators are non-zero"
+msgstr "Assume que os denominadores incógnitos são diferentes de zero"
+
+#: ../data/main.ui.h:177
+msgid "Non-Zero Denominators"
+msgstr "Denominadores diferentes de zero"
+
+#: ../data/main.ui.h:178
+msgid "Warn when unknown denominators are assumed non-zero"
+msgstr ""
+"Avisar quando denominadores incógnitos são assumidos diferentes de zero"
+
+#: ../data/main.ui.h:179
+msgid "Warn About Denominators Assumed Non-Zero"
+msgstr "Avisar sobre denominadores considerados diferentes de zero"
+
+#: ../data/main.ui.h:180 ../src/callbacks.cc:3278 ../src/callbacks.cc:20528
+msgid "Parsing Mode"
+msgstr "Modo de análise"
+
+#: ../data/main.ui.h:181
+msgid "Adaptive Parsing"
+msgstr "Análise adaptativa"
+
+#: ../data/main.ui.h:182
+msgid "Parse Implicit Multiplication First"
+msgstr "Analisar primeiro multiplicação implícita"
+
+#: ../data/main.ui.h:183
+msgid "Conventional Parsing"
+msgstr "Análise convencional"
+
+#: ../data/main.ui.h:184
+msgid "Chain Syntax"
+msgstr "Sintaxe de cadeia"
+
+#: ../data/main.ui.h:185
+msgid "RPN Syntax"
+msgstr "Sintaxe RPN"
+
+#: ../data/main.ui.h:187
+#, no-c-format
+msgid ""
+"Off: 100 + 20% = 100 +  20/100 = 100.2\n"
+"On: 100 + 20% = 100 × 120% = 120"
+msgstr ""
+"Desativado: 100 + 20% = 100 +  20/100 = 100,2\n"
+"Ativado: 100 + 20% = 100 × 120% = 120"
+
+#: ../data/main.ui.h:189
+msgid "Simplified Percentage Calculation"
+msgstr "Cálculo simplificado da percentagem"
+
+#: ../data/main.ui.h:190
+msgid ""
+"Off: xy = x × y\n"
+"On: xy != x × y"
+msgstr ""
+"Desativado: xy = x × y\n"
+"Ativado: xy != x × y"
+
+#: ../data/main.ui.h:192
+msgid "Limit Implicit Multiplication"
+msgstr "Limitar multiplicação implícita"
+
+#: ../data/main.ui.h:193
+msgid ""
+"Parse decimal numbers as approximate with precision equal to the number of "
+"digits.\n"
+"\n"
+"Off: 1.1 × 1.1 = 1.21\n"
+"On: 1.1 × 1.1 ≈ 1.2"
+msgstr ""
+"Analisa números decimais como aproximados com precisão igual ao número de "
+"dígitos.\n"
+"\n"
+"Desativado: 1,1 × 1,1 = 1,21\n"
+"Ativado: 1,1 × 1,1 ≈ 1,2"
+
+#: ../data/main.ui.h:197
+msgid "Read Precision"
+msgstr "Ler precisão"
+
+#: ../data/main.ui.h:198
+msgid "_Precision"
+msgstr "_Precisão"
+
+#: ../data/main.ui.h:199
+msgid "_Decimals"
+msgstr "_Decimais"
+
+#: ../data/main.ui.h:200
+msgid "Calculate As You Type"
+msgstr "Calcular ao digitar"
+
+#: ../data/main.ui.h:201
+msgid "Chain Mode"
+msgstr "Modo de cadeia"
+
+#: ../data/main.ui.h:202
+msgid "Activate the RPN stack."
+msgstr "Ative a pilha RPN."
+
+#: ../data/main.ui.h:203
+msgid "RPN Mode"
+msgstr "Modo RPN"
+
+#: ../data/main.ui.h:204 ../src/callbacks.cc:20549
+msgid "Meta Modes"
+msgstr "Meta Modos"
+
+#: ../data/main.ui.h:205 ../src/callbacks.cc:20561
+msgid "Save Mode…"
+msgstr "Gravar modo…"
+
+#: ../data/main.ui.h:206
+msgid "Delete Mode…"
+msgstr "Eliminar modo…"
+
+#: ../data/main.ui.h:207
+msgid "Save Default _Mode"
+msgstr "Gravar _modo padrão"
+
+#: ../data/main.ui.h:208
+msgid "Fu_nctions"
+msgstr "Fu_nções"
+
+#: ../data/main.ui.h:209
+msgid "_Variables"
+msgstr "_Variáveis"
+
+#: ../data/main.ui.h:210
+msgid "_Units"
+msgstr "_Unidades"
+
+#: ../data/main.ui.h:212
+msgid "_Contents"
+msgstr "_Conteúdo"
+
+#: ../data/main.ui.h:213
+msgid "Report a Bug"
+msgstr "Reportar um erro"
+
+#: ../data/main.ui.h:214
+msgid "Check for Updates"
+msgstr "Verificar atualizações"
+
+#: ../data/main.ui.h:215
+msgid "_About"
+msgstr "_Sobre"
+
+#: ../data/main.ui.h:216 ../src/callbacks.cc:7063
+msgid "Toggle minimal window"
+msgstr "Alternar janela mínima"
+
+#: ../data/main.ui.h:217
+msgid "Calculation result"
+msgstr "Resultado do cálculo"
+
+#: ../data/main.ui.h:218
+msgid "_Keypad"
+msgstr "_Teclado"
+
+#: ../data/main.ui.h:219
+msgid ""
+"Toggles persistent keypad (makes it possible to show keypad and history "
+"simultaneously)"
+msgstr ""
+"Ativar teclado persistente (permite mostrar o teclado numérico e o histórico "
+"simultaneamente)"
+
+#: ../data/main.ui.h:220
+msgid "_History"
+msgstr "_Histórico"
+
+#: ../data/main.ui.h:221
+msgid "C_onversion"
+msgstr "C_onversão"
+
+#: ../data/main.ui.h:222
+msgid "RPN Stack"
+msgstr "Pilha RPN"
+
+#: ../data/main.ui.h:223
+msgid "Insert the selected value"
+msgstr "Inserir o valor selecionado"
+
+#: ../data/main.ui.h:224
+msgid "Insert the selected text"
+msgstr "Inserir o texto selecionado"
+
+#: ../data/main.ui.h:225
+msgid "Copy the selected text"
+msgstr "Copiar o texto selecionado"
+
+#: ../data/main.ui.h:226
+msgid "Add the selected value(s)"
+msgstr "Adicionar os valores selecionados"
+
+#: ../data/main.ui.h:227
+msgid "Subtract the selected value(s)"
+msgstr "Subtrair os valores selecionados"
+
+#: ../data/main.ui.h:228
+msgid "Multiply the selected value(s)"
+msgstr "Multiplicar os valores selecionados"
+
+#: ../data/main.ui.h:229
+msgid "Divide the the selected value(s)"
+msgstr "Dividir os valores selecionados"
+
+#: ../data/main.ui.h:230
+msgid "Raise to the power of the selected value"
+msgstr "Aumentar a potência do valor selecionado"
+
+#: ../data/main.ui.h:231
+msgid "Calculate the square root of the selected value"
+msgstr "Calcular a raiz quadrada do valor selecionado"
+
+#: ../data/main.ui.h:232 ../src/interface.cc:2443
+msgid "History"
+msgstr "Histórico"
+
+#: ../data/main.ui.h:234
+msgid "Subtract the top value from the second value"
+msgstr "Subtrair o valor superior do segundo valor"
+
+#: ../data/main.ui.h:235
+msgid "Multiply the top two values"
+msgstr "Multiplicar os dois principais valores"
+
+#: ../data/main.ui.h:236
+msgid "Divide the second value by the top value"
+msgstr "Dividir o segundo valor pelo valor superior"
+
+#: ../data/main.ui.h:237
+msgid "Raise the second value to the power of the top value"
+msgstr "Aumentar o segundo valor para a potência do valor superior"
+
+#: ../data/main.ui.h:238
+msgid "Negate the top value (Ctrl+-)"
+msgstr "Negar o valor superior (Ctrl+-)"
+
+#: ../data/main.ui.h:239
+msgid "Invert the top value"
+msgstr "Inverter o valor superior"
+
+#: ../data/main.ui.h:240
+msgid "Calculate the square root of the top value"
+msgstr "Calcular a raiz quadrada do valor superior"
+
+#: ../data/main.ui.h:241
+msgid "Calculate the sum of all values"
+msgstr "Calcular a soma de todos os valores"
+
+#: ../data/main.ui.h:242 ../src/callbacks.cc:7224 ../src/callbacks.cc:7444
+msgid "Rotate the stack or move selected register up"
+msgstr "Rode a pilha ou mova o registo selecionado para cima"
+
+#: ../data/main.ui.h:243 ../src/callbacks.cc:7232 ../src/callbacks.cc:7445
+msgid "Rotate the stack or move selected register down"
+msgstr "Rode a pilha ou mova o registo selecionado para baixo"
+
+#: ../data/main.ui.h:244 ../src/callbacks.cc:7240 ../src/callbacks.cc:7446
+msgid ""
+"Swap the two top values or move the selected value to the top of the stack"
+msgstr ""
+"Troque os valores superiores ou mova o valor selecionado para o topo da pilha"
+
+#: ../data/main.ui.h:245 ../src/callbacks.cc:7248 ../src/callbacks.cc:7447
+msgid "Copy the selected or top value to the top of the stack"
+msgstr "Copie o valor selecionado ou superior para o topo da pilha"
+
+#: ../data/main.ui.h:246 ../src/callbacks.cc:7256 ../src/callbacks.cc:7448
+msgid "Enter the top value from before the last numeric operation"
+msgstr "Digite o valor superior antes da última operação numérica"
+
+#: ../data/main.ui.h:247 ../src/callbacks.cc:7264 ../src/callbacks.cc:7449
+msgid "Delete the top or selected value"
+msgstr "Eliminar o valor selecionado ou superior"
+
+#: ../data/main.ui.h:248
+msgid "Edit the selected value"
+msgstr "Editar o valor selecionado"
+
+#: ../data/main.ui.h:249 ../src/callbacks.cc:7272 ../src/callbacks.cc:7450
+msgid "Clear the RPN stack"
+msgstr "Limpar a pilha RPN"
+
+#: ../data/main.ui.h:251
+msgid "Unit(s) and prefix to convert result to"
+msgstr "Unidade(s) e prefixo para converter o resultado em"
+
+#: ../data/main.ui.h:253
+msgid "Convert"
+msgstr "Converter"
+
+#: ../data/main.ui.h:254
+msgid "Continuous conversion"
+msgstr "Conversão contínua"
+
+#: ../data/main.ui.h:255
+msgid ""
+"Automatically convert result to the current unit expression as long as the "
+"conversion box is visible."
+msgstr ""
+"Converter automaticamente o resultado na expressão de unidade atual, desde "
+"que a caixa de conversão esteja visível."
+
+#: ../data/main.ui.h:256
+msgid "Add prefix"
+msgstr "Adicionar prefixo"
+
+#: ../data/main.ui.h:257
+msgid ""
+"If unit expression does not contain any prefixes, use optimal prefix.\n"
+"\n"
+"This can be overridden by prepending the unit expression with \"?\" or \"0\"."
+msgstr ""
+"Se a expressão da unidade não contiver nenhum prefixo, use o prefixo "
+"ideal. \n"
+"Isto pode ser substituído ao adicionar a expressão da unidade com \"?\" ou "
+"\"0\"."
+
+#: ../data/main.ui.h:260
+msgid "Conversion"
+msgstr "Conversão"
+
+#: ../data/main.ui.h:261 ../src/callbacks.cc:7308 ../src/callbacks.cc:7457
+msgid "Show/hide programming keypad"
+msgstr "Mostrar/ocultar teclado de programação"
+
+#: ../data/main.ui.h:262 ../src/callbacks.cc:18858
+msgid "Exact"
+msgstr "Exato"
+
+#: ../data/main.ui.h:263 ../src/callbacks.cc:8376 ../src/callbacks.cc:8378
+msgid "Fraction"
+msgstr "Fração"
+
+#: ../data/main.ui.h:264
+msgid "Numerical display"
+msgstr "Exibição numérica"
+
+#: ../data/main.ui.h:265
+msgid "Pure"
+msgstr "Puro"
+
+#: ../data/main.ui.h:266
+msgid "Number base"
+msgstr "Base numérica"
+
+#: ../data/main.ui.h:267 ../data/setbase.ui.h:9
+msgid "Time format"
+msgstr "Formato de tempo"
+
+#: ../data/main.ui.h:268
+msgid "Roman"
+msgstr "Romano"
+
+#: ../data/main.ui.h:269
+msgid "sin"
+msgstr "sin"
+
+#: ../data/main.ui.h:270
+msgid "cos"
+msgstr "cos"
+
+#: ../data/main.ui.h:271
+msgid "tan"
+msgstr "tan"
+
+#: ../data/main.ui.h:272
+msgid "ln"
+msgstr "ln"
+
+#: ../data/main.ui.h:273
+msgid "Equals"
+msgstr "Igual a"
+
+#: ../data/main.ui.h:274
+msgid "sqrt"
+msgstr "sqrt"
+
+#: ../data/main.ui.h:275
+msgid "sum"
+msgstr "sum"
+
+#: ../data/main.ui.h:276
+msgid "Unknown variable"
+msgstr "Variável desconhecida"
+
+#: ../data/main.ui.h:277
+msgid "mod"
+msgstr "mod"
+
+#: ../data/main.ui.h:279
+msgid "mean"
+msgstr "mean"
+
+#: ../data/main.ui.h:280 ../src/interface.cc:1778
+msgid "Store result as a variable"
+msgstr "Guardar o resultado como uma variável"
+
+#. Standard calculator button. Do not use more than three characters.
+#: ../data/main.ui.h:282
+msgid "STO"
+msgstr "STO"
+
+#: ../data/main.ui.h:283
+msgid "Convert number bases"
+msgstr "Converter bases numéricas"
+
+#: ../data/main.ui.h:284
+msgid "Imaginary unit i (√-1)"
+msgstr "Unidade imaginária i (√-1)"
+
+#: ../data/main.ui.h:285 ../src/callbacks.cc:7066
+msgid "Manage units"
+msgstr "Gerir unidades"
+
+#: ../data/main.ui.h:287
+msgid "Conversion operator"
+msgstr "Operador de conversão"
+
+#: ../data/main.ui.h:289
+msgid "Kilogram"
+msgstr "Quilograma"
+
+#: ../data/main.ui.h:290
+msgid "Two's complement input"
+msgstr "Entrada do complemento para dois"
+
+#: ../data/main.ui.h:291
+msgid "Two's complement output"
+msgstr "Saída do complemento para dois"
+
+#: ../data/main.ui.h:292 ../data/nbases.ui.h:26 ../src/interface.cc:1277
+#: ../src/interface.cc:1454 ../src/interface.cc:1780 ../src/interface.cc:1781
+#: ../src/interface.cc:4500 ../src/callbacks.cc:24330 ../src/callbacks.cc:24331
+msgid "Bitwise Exclusive OR"
+msgstr "OR exclusivo bit-a-bit"
+
+#: ../data/main.ui.h:293 ../data/nbases.ui.h:32 ../src/interface.cc:1450
+msgid "Bitwise Left Shift"
+msgstr "Deslocamento à esquerda bit-a-bit"
+
+#: ../data/main.ui.h:294 ../data/nbases.ui.h:33 ../src/interface.cc:1451
+msgid "Bitwise Right Shift"
+msgstr "Deslocamento à direita bit-a-bit"
+
+#: ../data/main.ui.h:295
+msgid "Floating point conversion"
+msgstr "Conversão de ponto flutuante"
+
+#: ../data/main.ui.h:296
+msgid "Show/hide left keypad"
+msgstr "Mostrar/ocultar teclado numérico esquerdo"
+
+#: ../data/main.ui.h:297
+msgid "Show/hide right keypad"
+msgstr "Mostrar/ocultar teclado numérico direito"
+
+#. Standard calculator button. Do not use more than three characters.
+#: ../data/main.ui.h:299 ../data/nbases.ui.h:29 ../src/interface.cc:1284
+msgid "DEL"
+msgstr "DEL"
+
+#. Standard calculator button. Do not use more than three characters.
+#: ../data/main.ui.h:301 ../data/nbases.ui.h:31 ../src/interface.cc:1283
+msgid "AC"
+msgstr "AC"
+
+#: ../data/main.ui.h:302 ../src/interface.cc:1285 ../src/interface.cc:4507
+msgid "Previous result"
+msgstr "Resultado anterior"
+
+#. Standard calculator button. Do not use more than three characters.
+#: ../data/main.ui.h:304 ../src/interface.cc:1285
+msgid "ANS"
+msgstr "ANS"
+
+#: ../data/main.ui.h:305 ../src/interface.cc:1238
+msgid "EXP"
+msgstr "EXP"
+
+#: ../data/main.ui.h:306
+msgid "Add to Expression"
+msgstr "Adicionar à Expressão"
+
+#: ../data/main.ui.h:307
+msgid "Persistent Keypad"
+msgstr "Teclado persistente"
+
+#: ../data/main.ui.h:308
+msgid "Edit"
+msgstr "Editar"
+
+#: ../data/main.ui.h:309 ../data/nbases.ui.h:28 ../src/interface.cc:1284
+#: ../src/interface.cc:4506
+msgid "Delete"
+msgstr "Eliminar"
+
+#: ../data/main.ui.h:310
+msgid "Update"
+msgstr "Atualizar"
+
+#: ../data/main.ui.h:311
+msgid "Insert Value"
+msgstr "Inserir valor"
+
+#: ../data/main.ui.h:312
+msgid "Insert Text"
+msgstr "Inserir texto"
+
+#: ../data/main.ui.h:313
+msgid "Insert Parsed Text"
+msgstr "Inserir texto analisado"
+
+#: ../data/main.ui.h:314 ../src/searchprovider.cc:238
+msgid "Copy"
+msgstr "Copiar"
+
+#: ../data/main.ui.h:315
+msgid "Copy Unformatted ASCII"
+msgstr "Copiar ASCII não formatado"
+
+#: ../data/main.ui.h:316
+msgid "Copy Full Text"
+msgstr "Copiar todo o texto"
+
+#: ../data/main.ui.h:317
+msgid "Search…"
+msgstr "Procurar…"
+
+#: ../data/main.ui.h:318 ../src/callbacks.cc:28986
+msgid "Add Bookmark…"
+msgstr "Adicionar marcador…"
+
+#: ../data/main.ui.h:319
+msgid "Bookmarks"
+msgstr "Marcador"
+
+#: ../data/main.ui.h:320
+msgid "Protect"
+msgstr "Proteger"
+
+#: ../data/main.ui.h:321
+msgid "Move To Top"
+msgstr "Mover para o topo"
+
+#: ../data/main.ui.h:322
+msgid "Remove"
+msgstr "Remover"
+
+#: ../data/main.ui.h:323
+msgid "Clear All"
+msgstr "Limpar tudo"
+
+#: ../data/main.ui.h:324
+msgid "_Copy"
+msgstr "_Copiar"
+
+#: ../data/main.ui.h:325
+msgid "_Store…"
+msgstr "_Armazenar…"
+
+#: ../data/main.ui.h:326
+msgid "Save Image…"
+msgstr "Gravar imagem…"
+
+#: ../data/main.ui.h:327
+msgid "_Factorize"
+msgstr "_Fatorar"
+
+#: ../data/main.ui.h:328
+msgid "_Expand"
+msgstr "_Expandir"
+
+#: ../data/main.ui.h:329
+msgid "_Normal"
+msgstr "_Normal"
+
+#: ../data/main.ui.h:330
+msgid "Sc_ientific"
+msgstr "C_ientífica"
+
+#: ../data/main.ui.h:331
+msgid "Purel_y Scientific"
+msgstr "Pura_mente científica"
+
+#: ../data/main.ui.h:332
+msgid "Simp_le"
+msgstr "Simp_les"
+
+#: ../data/main.ui.h:333
+msgid "_Binary"
+msgstr "_Binária"
+
+#: ../data/main.ui.h:334
+msgid "_Octal"
+msgstr "_Octal"
+
+#: ../data/main.ui.h:335
+msgid "_Decimal"
+msgstr "_Decimal"
+
+#: ../data/main.ui.h:336
+msgid "_Hexadecimal"
+msgstr "_Hexadecimal"
+
+#: ../data/main.ui.h:337 ../src/callbacks.cc:8380
+msgid "Decimal Fraction"
+msgstr "Fração decimal"
+
+#: ../data/main.ui.h:338
+msgid "Exact Decimal Fraction"
+msgstr "Fração decimal exata"
+
+#: ../data/main.ui.h:339
+msgid "Simple Fraction"
+msgstr "Fração simples"
+
+#: ../data/main.ui.h:340
+msgid "Mixed Fraction"
+msgstr "Fração mista"
+
+#: ../data/main.ui.h:341
+msgid "_Abbreviate Names"
+msgstr "_Abreviar nomes"
+
+#: ../data/main.ui.h:342
+msgid "C_onvert…"
+msgstr "C_onverter…"
+
+#: ../data/main.ui.h:343
+msgid "Convert to Base _Units"
+msgstr "Converter em _unidades base"
+
+#: ../data/main.ui.h:344
+msgid "Convert _to Optimal Unit"
+msgstr "Conver_ter em unidade ideal"
+
+#: ../data/main.ui.h:345
+msgid "Use Optimal Prefix"
+msgstr "Usar prefixo ideal"
+
+#: ../data/main.ui.h:346
+msgid "Convert to"
+msgstr "Converter para"
+
+#: ../data/main.ui.h:347
+msgid "Convert to UTC"
+msgstr "Converter para UTC"
+
+#: ../data/main.ui.h:348
+msgid "Convert to Calendars"
+msgstr "Converter em calendários"
+
+#: ../data/main.ui.h:349
+msgid "Use prefixes for all units"
+msgstr "Usar prefixos em todas as unidades"
+
+#: ../data/main.ui.h:350
+msgid "Enable All SI Prefi_xes"
+msgstr "Ativar Todos os Prefi_xos SI"
+
+#: ../data/main.ui.h:351
+msgid "View/Edit Matrix"
+msgstr "Ver/Editar Matriz"
+
+#: ../data/main.ui.h:352
+msgid "View/Edit Vector"
+msgstr "Ver/Editar Vetor"
+
+#: ../data/main.ui.h:353
+msgid "Copy Text"
+msgstr "Copiar texto"
+
+#: ../data/main.ui.h:354
+msgid "To Top"
+msgstr "Para cima"
+
+#: ../data/main.ui.h:355
+msgid "Swap"
+msgstr "Trocar"
+
+#: ../data/main.ui.h:356
+msgid "Up"
+msgstr "Acima"
+
+#: ../data/main.ui.h:357
+msgid "Down"
+msgstr "Abaixo"
+
+#: ../data/main.ui.h:358
+msgid "Negate"
+msgstr "Negar"
+
+#: ../data/main.ui.h:359
+msgid "Invert"
+msgstr "Inverter"
+
+#: ../data/main.ui.h:360
+msgid "Square"
+msgstr "Quadrado"
+
+#: ../data/main.ui.h:361
+msgid "Square Root"
+msgstr "Raiz quadrada"
+
+#: ../data/main.ui.h:362
+msgid "Clear Stack"
+msgstr "Limpar pilha"
+
+#: ../data/main.ui.h:363
+msgid "Select Number Base…"
+msgstr "Selecionar Base Numérica…"
+
+#: ../data/main.ui.h:364 ../src/callbacks.cc:7068
+msgid "Store result"
+msgstr "Guardar resultado"
+
+#. Add current result to variable value
+#: ../data/main.ui.h:366
+msgid "Add result"
+msgstr "Adicionar resultado"
+
+#. Subtruct current result from variable value
+#: ../data/main.ui.h:368
+msgid "Subtract result"
+msgstr "Subtrair resultado"
+
+#: ../data/matrix.ui.h:4 ../data/units.ui.h:19 ../data/variables.ui.h:14
+#: ../src/callbacks.cc:16427
+msgid "_Insert"
+msgstr "_Inserir"
+
+#: ../data/matrix.ui.h:5
+msgid "Insert the matrix/vector into the expression"
+msgstr "Inserir a matriz/vetor na expressão"
+
+#: ../data/matrix.ui.h:6 ../data/matrixedit.ui.h:7 ../src/callbacks.cc:36267
+#: ../src/callbacks.cc:36275
+msgid "Elements"
+msgstr "Elementos"
+
+#: ../data/matrix.ui.h:7 ../data/matrixedit.ui.h:9
+msgid "Number of rows in this matrix (rows displayed for vectors)"
+msgstr "Número de linhas nesta matriz (linhas exibidas para vetores)"
+
+#: ../data/matrix.ui.h:8 ../data/matrixedit.ui.h:10
+msgid "Number of columns in this matrix (columns displayed for vectors)"
+msgstr "Número de colunas nesta matriz (colunas exibidas para vetores)"
+
+#: ../data/matrix.ui.h:9 ../data/matrixedit.ui.h:12
+msgid "If this is a matrix or vector"
+msgstr "Se isto é uma matriz ou vetor"
+
+#: ../data/matrix.ui.h:11 ../data/matrixedit.ui.h:14
+msgid "Current element:"
+msgstr "Elemento atual:"
+
+#: ../data/matrixedit.ui.h:1 ../src/callbacks.cc:18319
+msgid "Edit Matrix"
+msgstr "Editar Matriz"
+
+#: ../data/matrixedit.ui.h:5
+msgid "Accept the creation/modification of this matrix/vector"
+msgstr "Aceitar a criação/modificação desta matriz/vetor"
+
+#: ../data/matrixedit.ui.h:8 ../data/variableedit.ui.h:6
+msgid "Name used to reference this variable in expressions"
+msgstr "Nome usado para referenciar esta variável em expressões"
+
+#: ../data/matrixedit.ui.h:15 ../data/unknownedit.ui.h:21
+#: ../data/variableedit.ui.h:8
+msgid "Temporary"
+msgstr "Temporária"
+
+#: ../data/matrixedit.ui.h:17 ../data/variableedit.ui.h:15
+msgid "Hide variable"
+msgstr "Ocultar variável"
+
+#: ../data/namesedit.ui.h:1
+msgid "Names"
+msgstr "Nomes"
+
+#: ../data/nbases.ui.h:1 ../data/setbase.ui.h:1 ../src/callbacks.cc:8343
+msgid "Number Bases"
+msgstr "Bases Numéricas"
+
+#: ../data/nbases.ui.h:6
+msgid "Binary value"
+msgstr "Valor binário"
+
+#: ../data/nbases.ui.h:7
+msgid "Decimal value"
+msgstr "Valor decimal"
+
+#: ../data/nbases.ui.h:8
+msgid "Octal value"
+msgstr "Valor octal"
+
+#: ../data/nbases.ui.h:9 ../data/setbase.ui.h:10 ../src/callbacks.cc:34039
+#: ../src/callbacks.cc:34081
+msgid "Roman numerals"
+msgstr "Números romanos"
+
+#: ../data/nbases.ui.h:12
+msgid "Hexadecimal value"
+msgstr "Valor hexadecimal"
+
+#: ../data/nbases.ui.h:13
+msgid "Show/hide keypad"
+msgstr "Mostrar/ocultar teclado"
+
+#: ../data/nbases.ui.h:14 ../src/callbacks.cc:2320
+msgid "BIN"
+msgstr "BIN"
+
+#: ../data/nbases.ui.h:15 ../src/callbacks.cc:2325
+msgid "OCT"
+msgstr "OCT"
+
+#: ../data/nbases.ui.h:16
+msgid "DEC"
+msgstr "DEC"
+
+#: ../data/nbases.ui.h:17 ../src/callbacks.cc:2330
+msgid "DUO"
+msgstr "DUO"
+
+#: ../data/nbases.ui.h:18 ../src/callbacks.cc:2335
+msgid "HEX"
+msgstr "HEX"
+
+#: ../data/nbases.ui.h:19
+msgid "ROM"
+msgstr "ROM"
+
+#: ../data/nbases.ui.h:21 ../src/interface.cc:1281 ../src/interface.cc:4504
+msgid "Subtract"
+msgstr "Subtrair"
+
+#: ../data/nbases.ui.h:22 ../src/interface.cc:1277 ../src/interface.cc:4500
+msgid "Multiply"
+msgstr "Multiplicar"
+
+#: ../data/nbases.ui.h:23 ../src/interface.cc:1276 ../src/interface.cc:4499
+msgid "Divide"
+msgstr "Dividir"
+
+#: ../data/nbases.ui.h:24 ../src/interface.cc:1278 ../src/interface.cc:1452
+#: ../src/interface.cc:1769 ../src/interface.cc:4501
+msgid "Bitwise AND"
+msgstr "Bit-a-bit AND"
+
+#: ../data/nbases.ui.h:25 ../src/interface.cc:1281 ../src/interface.cc:1453
+#: ../src/interface.cc:1770 ../src/interface.cc:4504
+msgid "Bitwise OR"
+msgstr "Bit-a-bit OR"
+
+#: ../data/nbases.ui.h:27 ../src/interface.cc:1455 ../src/interface.cc:1771
+msgid "Bitwise NOT"
+msgstr "Bit-a-bit NOT"
+
+#: ../data/nbases.ui.h:30 ../data/percentage.ui.h:4 ../src/interface.cc:1283
+#: ../src/interface.cc:4505 ../src/callbacks.cc:20480
+msgid "Clear"
+msgstr "Limpar"
+
+#: ../data/percentage.ui.h:1
+msgid ""
+"Enter two values, of which at most one is a percentage, and the others will "
+"be calculated for you."
+msgstr ""
+"Introduza dois valores, dos quais no máximo um é uma percentagem, e os "
+"outros serão calculados para si."
+
+#: ../data/percentage.ui.h:2
+msgid "Percentage"
+msgstr "Percentagem"
+
+#: ../data/percentage.ui.h:3
+msgid "Calculate"
+msgstr "Calcular"
+
+#: ../data/percentage.ui.h:6
+msgid "Value 1"
+msgstr "Valor 1"
+
+#: ../data/percentage.ui.h:7
+msgid "2 compared to 1"
+msgstr "2 comparado a 1"
+
+#: ../data/percentage.ui.h:8
+msgid "Change from 1 to 2"
+msgstr "Alterar de 1 para 2"
+
+#: ../data/percentage.ui.h:9
+msgid "Value 2"
+msgstr "Valor 2"
+
+#: ../data/percentage.ui.h:10
+msgid "1 compared to 2"
+msgstr "1 comparado a 2"
+
+#: ../data/percentage.ui.h:11
+msgid "Change from 2 to 1"
+msgstr "Alterar de 2 para 1"
+
+#: ../data/plot.ui.h:1
+msgid "Plot"
+msgstr "Parcela"
+
+#: ../data/plot.ui.h:3 ../src/callbacks.cc:21012 ../src/callbacks.cc:32378
+#: ../src/callbacks.cc:32380 ../src/callbacks.cc:37752
+#: ../src/callbacks.cc:37754
+msgid "_Save"
+msgstr "_Gravar"
+
+#: ../data/plot.ui.h:4
+msgid "Save as png, svg, postscript, eps, latex or fig"
+msgstr "Gravar como png, svg, postscript, eps, latex ou fig"
+
+#: ../data/plot.ui.h:7 ../src/interface.cc:3487 ../src/interface.cc:4227
+msgid "Title"
+msgstr "Título"
+
+#: ../data/plot.ui.h:10
+msgid "Vector/matrix"
+msgstr "Vetor/matriz"
+
+#: ../data/plot.ui.h:11
+msgid "Paired matrix"
+msgstr "Matriz emparelhada"
+
+#: ../data/plot.ui.h:12
+msgid "Rows"
+msgstr "Linhas"
+
+#: ../data/plot.ui.h:13
+msgid "if you want to split matrix in rows instead of columns"
+msgstr "se desejar dividir a matriz em linhas em vez de colunas"
+
+#: ../data/plot.ui.h:14
+msgid "X variable"
+msgstr "Variável X"
+
+#: ../data/plot.ui.h:15
+msgid "The variable name used in expression"
+msgstr "O nome da variável usada na expressão"
+
+#: ../data/plot.ui.h:16
+msgid "Style"
+msgstr "Estilo"
+
+#: ../data/plot.ui.h:17
+msgid "Line"
+msgstr "Linha"
+
+#: ../data/plot.ui.h:18
+msgid "Points"
+msgstr "Pontos"
+
+#: ../data/plot.ui.h:19
+msgid "Line with points"
+msgstr "Linha com pontos"
+
+#: ../data/plot.ui.h:20
+msgid "Boxes/bars"
+msgstr "Caixas/barras"
+
+#: ../data/plot.ui.h:21
+msgid "Histogram"
+msgstr "Histograma"
+
+#: ../data/plot.ui.h:22
+msgid "Steps"
+msgstr "Passos"
+
+#: ../data/plot.ui.h:23
+msgid "Candlesticks"
+msgstr "Castiçais"
+
+#: ../data/plot.ui.h:24
+msgid "Dots"
+msgstr "Pontos"
+
+#: ../data/plot.ui.h:25
+msgid "Polar"
+msgstr "Polar"
+
+#: ../data/plot.ui.h:26
+msgid "Smoothing"
+msgstr "Suavização"
+
+#: ../data/plot.ui.h:28
+msgid "Monotonic"
+msgstr "Monotónica"
+
+#: ../data/plot.ui.h:29
+msgid "Natural cubic splines"
+msgstr "Estrias cúbicas naturais"
+
+#: ../data/plot.ui.h:30
+msgid "Bezier"
+msgstr "Bezier"
+
+#: ../data/plot.ui.h:31
+msgid "Bezier (monotonic)"
+msgstr "Bezier (monotónica)"
+
+#: ../data/plot.ui.h:32
+msgid "Y-axis"
+msgstr "Eixo Y"
+
+#: ../data/plot.ui.h:33
+msgid "Primary"
+msgstr "Primário"
+
+#: ../data/plot.ui.h:34
+msgid "Secondary"
+msgstr "Secundário"
+
+#: ../data/plot.ui.h:38
+msgid "Data"
+msgstr "Dados"
+
+#: ../data/plot.ui.h:39
+msgid "Minimum x value"
+msgstr "Valor mínimo x"
+
+#: ../data/plot.ui.h:40
+msgid "Maximum x value"
+msgstr "Valor máximo x"
+
+#: ../data/plot.ui.h:41
+msgid "Sampling rate"
+msgstr "Taxa de amostragem"
+
+#: ../data/plot.ui.h:42
+msgid "Step size"
+msgstr "Tamanho do passo"
+
+#: ../data/plot.ui.h:43
+msgid "Function Range"
+msgstr "Intervalo da função"
+
+#: ../data/plot.ui.h:44
+msgid "Display grid"
+msgstr "Mostrar grelha"
+
+#: ../data/plot.ui.h:45
+msgid "Display full border"
+msgstr "Mostrar o contorno inteiro"
+
+#: ../data/plot.ui.h:46
+msgid "Minimum y value"
+msgstr "Valor mínimo y"
+
+#: ../data/plot.ui.h:47
+msgid "Maximum y value"
+msgstr "Valor máximo y"
+
+#: ../data/plot.ui.h:48
+msgid "Logarithmic x scale"
+msgstr "Escala logarítmica x"
+
+#: ../data/plot.ui.h:49
+msgid "Logarithmic y scale"
+msgstr "Escala logarítmica y"
+
+#: ../data/plot.ui.h:50
+msgid "X-axis label"
+msgstr "Etiqueta do eixo X"
+
+#: ../data/plot.ui.h:51
+msgid "Y-axis label"
+msgstr "Etiqueta do eixo Y"
+
+#: ../data/plot.ui.h:52
+msgid "Line width"
+msgstr "Espessura da linha"
+
+#: ../data/plot.ui.h:53
+msgid "Color display"
+msgstr "Exibição de cores"
+
+#: ../data/plot.ui.h:54
+msgid "Color"
+msgstr "Cores"
+
+#: ../data/plot.ui.h:55
+msgid "Monochrome"
+msgstr "Monocromática"
+
+#: ../data/plot.ui.h:56
+msgid "Legend placement"
+msgstr "Posição da legenda"
+
+#: ../data/plot.ui.h:57
+msgid "Top-left"
+msgstr "Superior esquerdo"
+
+#: ../data/plot.ui.h:58
+msgid "Top-right"
+msgstr "Superior direito"
+
+#: ../data/plot.ui.h:59
+msgid "Bottom-left"
+msgstr "Inferior esquerdo"
+
+#: ../data/plot.ui.h:60
+msgid "Bottom-right"
+msgstr "Inferior direito"
+
+#: ../data/plot.ui.h:61
+msgid "Below"
+msgstr "Abaixo"
+
+#: ../data/plot.ui.h:62
+msgid "Outside"
+msgstr "Fora"
+
+#: ../data/plot.ui.h:63
+msgid "Appearance"
+msgstr "Aparência"
+
+#: ../data/precision.ui.h:1
+msgid "Precision"
+msgstr "Precisão"
+
+#: ../data/precision.ui.h:4
+msgid "_Recalculate"
+msgstr "_Recalcular"
+
+#: ../data/precision.ui.h:5
+msgid "Recalculate expression"
+msgstr "Recalcular expressão"
+
+#: ../data/precision.ui.h:6
+msgid ""
+"The number of significant digits to display/calculate (simple arithmetics "
+"are always calculated exact)"
+msgstr ""
+"O número de dígitos significativos a serem exibidos/calculados (aritmética "
+"simples é sempre calculada exatamente)"
+
+#: ../data/preferences.ui.h:1
+msgid "Preferences"
+msgstr "Preferências"
+
+#: ../data/preferences.ui.h:3
+msgid "Save definitions on exit"
+msgstr "Gravar definições ao sair"
+
+#: ../data/preferences.ui.h:4
+msgid ""
+"If changes to functions, units and variables shall be saved automatically"
+msgstr ""
+"Para que alterações em funções, unidades e variáveis sejam guardadas "
+"automaticamente"
+
+#: ../data/preferences.ui.h:5
+msgid "Clear history on exit"
+msgstr "Limpar histórico ao sair"
+
+#: ../data/preferences.ui.h:6
+msgid "Allow multiple instances"
+msgstr "Permitir várias instâncias"
+
+#: ../data/preferences.ui.h:7
+msgid ""
+"Allow multiple instances of the Qalculate! main window to be open at the "
+"same time.\n"
+"\n"
+"Note that only the mode, history and definitions of the last closed instance "
+"will be saved."
+msgstr ""
+"Permite que várias instâncias da janela principal do Qalculate! sejam "
+"abertas. \n"
+"\n"
+"Observe que apenas o modo, histórico e definições da última instância "
+"fechada serão guardados."
+
+#: ../data/preferences.ui.h:10
+msgid "Notify when a new version is available"
+msgstr "Notificar quando uma nova versão estiver disponível"
+
+#: ../data/preferences.ui.h:11
+msgid "Save mode on exit"
+msgstr "Gravar modo ao sair"
+
+#: ../data/preferences.ui.h:12
+msgid "If the mode of the calculator shall be restored"
+msgstr "Para que o modo da calculadora seja restaurado"
+
+#: ../data/preferences.ui.h:13
+msgid "Close application with Escape key"
+msgstr "Fechar a aplicação com a tecla Escape"
+
+#: ../data/preferences.ui.h:14
+msgid ""
+"Close the application with the Escape key if the expression field is empty."
+msgstr ""
+"Fechar a aplicação com a tecla Escape se o campo de expressão estiver vazio."
+
+#: ../data/preferences.ui.h:15
+msgid "Use keyboard keys for RPN"
+msgstr "Usar teclado para RPN"
+
+#: ../data/preferences.ui.h:16
+msgid "Use keyboard operator keys for RPN operations (+-*/^)."
+msgstr "Usar as teclas de operação no teclado para operações RPN (+-*/^)."
+
+#: ../data/preferences.ui.h:17
+msgid "Use caret for bitwise XOR"
+msgstr "Usar acento circunflexo para XOR bit-a-bit"
+
+#: ../data/preferences.ui.h:18
+msgid ""
+"Input XOR (⊻) using caret (^) on keyboard (otherwise use Ctrl+^). The "
+"exponentiation operator (^) can always be input using Ctrl+*."
+msgstr ""
+"Inserir XOR (⊻) usando circunflexo (^) no teclado (caso contrário, use "
+"Ctrl+^). O operador de exponenciação (^) sempre pode ser inserido ao usar "
+"Ctrl+*."
+
+#: ../data/preferences.ui.h:19
+msgid "Expression in history"
+msgstr "Expressão no histórico"
+
+#: ../data/preferences.ui.h:20
+msgid "Parsed"
+msgstr "Analisado"
+
+#: ../data/preferences.ui.h:21
+msgid "Entered"
+msgstr "Inserido"
+
+#: ../data/preferences.ui.h:22
+msgid "Entered + parsed"
+msgstr "Introduzido + analisado"
+
+#: ../data/preferences.ui.h:23
+msgid "Add calculate-as-you-type result to history"
+msgstr "Adicionar o resultado do cálculo à medida que digita ao histórico"
+
+#: ../data/preferences.ui.h:24
+msgid "Delay:"
+msgstr "Atraso:"
+
+#: ../data/preferences.ui.h:25
+msgid "Time limit for plot:"
+msgstr "Tempo limite para parcela:"
+
+#: ../data/preferences.ui.h:26
+msgid "Behavior"
+msgstr "Comportamento"
+
+#: ../data/preferences.ui.h:27
+msgid "Enable Unicode symbols"
+msgstr "Ativar símbolos Unicode"
+
+#: ../data/preferences.ui.h:28
+msgid "Disable this if you have problems with some fancy characters"
+msgstr "Desative isto se tiver problemas com alguns caracteres extravagantes"
+
+#: ../data/preferences.ui.h:29
+msgid "Ignore system language (requires restart)"
+msgstr "Ignorar o idioma do sistema (requer reinício)"
+
+#: ../data/preferences.ui.h:30
+msgid "Use system tray icon"
+msgstr "Usar ícone da área de notificação"
+
+#: ../data/preferences.ui.h:31
+msgid "Hides the application in the system tray when the main window is closed"
+msgstr ""
+"Oculta a aplicação na área de notificação do sistema quando a janela "
+"principal é fechada"
+
+#: ../data/preferences.ui.h:32
+msgid "Hide on startup"
+msgstr "Ocultar no arranque"
+
+#: ../data/preferences.ui.h:33
+msgid "Remember window position"
+msgstr "Lembrar posição da janela"
+
+#: ../data/preferences.ui.h:34
+msgid "Keep above other windows"
+msgstr "Manter acima das outras janelas"
+
+#: ../data/preferences.ui.h:35
+msgid ""
+"Keep the main window above other windows (depending on platform and settings "
+"this might not work)"
+msgstr ""
+"Manter a janela principal acima das outras janelas (dependendo da plataforma "
+"e das definições, isto pode não funcionar)"
+
+#: ../data/preferences.ui.h:36
+msgid "Button padding"
+msgstr "Preenchimento de botões"
+
+#: ../data/preferences.ui.h:37 ../src/callbacks.cc:7140
+#: ../src/callbacks.cc:18856 ../src/callbacks.cc:20240
+#: ../src/callbacks.cc:21256 ../src/callbacks.cc:37453
+msgid "Default"
+msgstr "Padrão"
+
+#: ../data/preferences.ui.h:38
+msgid "/"
+msgstr "/"
+
+#: ../data/preferences.ui.h:39
+msgid "Application name"
+msgstr "Nome do programa"
+
+#: ../data/preferences.ui.h:40
+msgid "Result"
+msgstr "Resultado"
+
+#: ../data/preferences.ui.h:41
+msgid "Application name + result"
+msgstr "Nome do programa + resultado"
+
+#: ../data/preferences.ui.h:42 ../src/callbacks.cc:21075
+msgid "Mode"
+msgstr "Modo"
+
+#: ../data/preferences.ui.h:43
+msgid "Application name + mode"
+msgstr "Nome do programa + modo"
+
+#: ../data/preferences.ui.h:44
+msgid "Window title"
+msgstr "Título da janela"
+
+#: ../data/preferences.ui.h:45
+msgid "Theme"
+msgstr "Tema"
+
+#: ../data/preferences.ui.h:46
+msgid "Light"
+msgstr "Claro"
+
+#: ../data/preferences.ui.h:47
+msgid "Dark"
+msgstr "Escuro"
+
+#: ../data/preferences.ui.h:48
+msgid "High contrast"
+msgstr "Alto contraste"
+
+#: ../data/preferences.ui.h:49
+msgid "Dark high contrast"
+msgstr "Escuro de alto contraste"
+
+#: ../data/preferences.ui.h:50
+msgid "Language"
+msgstr "Idioma"
+
+#: ../data/preferences.ui.h:51
+msgid "Tooltips"
+msgstr "Dicas"
+
+#: ../data/preferences.ui.h:52
+msgid "Show all"
+msgstr "Mostrar tudo"
+
+#: ../data/preferences.ui.h:53
+msgid "Hide in keypad"
+msgstr "Ocultar no teclado numérico"
+
+#: ../data/preferences.ui.h:54
+msgid "Hide all"
+msgstr "Ocultar tudo"
+
+#: ../data/preferences.ui.h:55
+msgid "Number of expression lines"
+msgstr "Número de linhas de expressão"
+
+#: ../data/preferences.ui.h:56
+msgid "Display expression status"
+msgstr "Mostrar estado da expressão"
+
+#: ../data/preferences.ui.h:57
+msgid ""
+"If as-you-type expression status shall be displayed below the expression "
+"entry"
+msgstr ""
+"Para que o estado da expressão, conforme digita, seja exibido abaixo da "
+"entrada da expressão"
+
+#: ../data/preferences.ui.h:58
+msgid "Persistent keypad"
+msgstr "Teclado persistente"
+
+#: ../data/preferences.ui.h:59
+msgid "Look & Feel"
+msgstr "Aparência"
+
+#: ../data/preferences.ui.h:60
+msgid "Binary two's complement representation"
+msgstr "Representação binária do complemento para dois"
+
+#: ../data/preferences.ui.h:61
+msgid ""
+"If two's complement representation shall be used for negative binary numbers."
+msgstr ""
+"Para que a representação do complemento para dois seja usada para números "
+"binários negativos."
+
+#: ../data/preferences.ui.h:62
+msgid "Hexadecimal two's complement representation"
+msgstr "Representação hexadecimal do complemento para dois"
+
+#: ../data/preferences.ui.h:63
+msgid ""
+"If two's complement representation shall be used for negative hexadecimal "
+"numbers."
+msgstr ""
+"Para que a representação do complemento para dois seja usada para números "
+"hexadecimais negativos."
+
+#: ../data/preferences.ui.h:64
+msgid "Use lower case letters in non-decimal numbers"
+msgstr "Usar letras minúsculas em números não-decimais"
+
+#: ../data/preferences.ui.h:65
+msgid "If lower case letters should be used in numbers with non-decimal base"
+msgstr ""
+"Para que letras minúsculas sejam usadas em números com base não-decimal"
+
+#: ../data/preferences.ui.h:66
+msgid "Use special duodecimal symbols"
+msgstr "Utilizar símbolos duodecimais especiais"
+
+#: ../data/preferences.ui.h:67
+msgid ""
+"If ↊ and ↋ (or X and E) shall be used instead of A and B for digits 10 and "
+"11 in numbers with base 12"
+msgstr ""
+"Se ↊ e ↋ (ou X e E) devem ser utilizados em vez de A e B para os algarismos "
+"10 e 11 em números de base 12"
+
+#: ../data/preferences.ui.h:68
+msgid "Alternative base prefixes"
+msgstr "Prefixos base alternativos"
+
+#: ../data/preferences.ui.h:69
+msgid ""
+"If hexadecimal numbers shall be displayed with \"0x0\" and binary numbers "
+"with \"0b00\" as prefixes"
+msgstr ""
+"Para que números hexadecimais sejam exibidos com \"0x0\" e números binários "
+"com \"0b00\" como prefixos"
+
+#: ../data/preferences.ui.h:70
+msgid "Spell out logical operators"
+msgstr "Soletrar operadores lógicos"
+
+#: ../data/preferences.ui.h:71
+msgid "If logical and/or shall be displayed as \"&&\"/\"||\" or \"and\"/\"or\""
+msgstr ""
+"Para que o lógico and/or seja exibido como \"&&\"/\"||\" ou \"and\"/\"or\""
+
+#: ../data/preferences.ui.h:72
+msgid "If \"e\" shall be used instead of \"E\" in numbers"
+msgstr "Para que \"e\" seja usado em vez de \"E\" em números"
+
+#: ../data/preferences.ui.h:73
+msgid "Use E-notation instead of 10<sup><i>n</i></sup>"
+msgstr "Usar notação E em vez de 10<sup><i>n</i></sup>"
+
+#: ../data/preferences.ui.h:74
+msgid "Use lower case \"e\" (as in 1e10)"
+msgstr "Usar letras minúsculas \"e\" (como em 1e10)"
+
+#: ../data/preferences.ui.h:75
+msgid "Use 'j' as imaginary unit"
+msgstr "Usar 'j' como unidade imaginária"
+
+#: ../data/preferences.ui.h:76
+msgid ""
+"Use 'j' (instead of 'i') as default symbol for the imaginary unit, and place "
+"it in front of the imaginary part."
+msgstr ""
+"Usar 'j' (em vez de 'i') como símbolo padrão para a unidade imaginária e "
+"coloque-o na frente da parte imaginária."
+
+#: ../data/preferences.ui.h:77
+msgid "Use comma as decimal separator"
+msgstr "Usar vírgula como separador decimal"
+
+#: ../data/preferences.ui.h:78
+msgid "Ignore comma in numbers"
+msgstr "Ignorar vírgula em números"
+
+#: ../data/preferences.ui.h:79
+msgid ""
+"Allow commas, ',', to be used as thousands separator instead of as an "
+"function argument separator"
+msgstr ""
+"Permite que vírgulas, ',',  sejam usadas como separador de milhares em vez "
+"de como separador de argumentos de função"
+
+#: ../data/preferences.ui.h:80
+msgid "Ignore dots in numbers"
+msgstr "Ignorar pontos em números"
+
+#: ../data/preferences.ui.h:81
+msgid ""
+"Allow dots, '.', to be used as thousands separator instead of as an "
+"alternative decimal sign"
+msgstr ""
+"Permite que pontos, '.',  sejam usados como separador de milhares em vez de "
+"como um sinal decimal alternativo"
+
+#: ../data/preferences.ui.h:82
+msgid "Copy result as unformatted ASCII by default"
+msgstr "Copiar o resultado como ASCII não formatado por defeito"
+
+#: ../data/preferences.ui.h:83
+msgid "Digit grouping"
+msgstr "Agrupamento de dígitos"
+
+#: ../data/preferences.ui.h:84
+msgid "off"
+msgstr "desligado"
+
+#: ../data/preferences.ui.h:85
+msgid "standard"
+msgstr "padrão"
+
+#: ../data/preferences.ui.h:86
+msgid "local"
+msgstr "local"
+
+#: ../data/preferences.ui.h:87
+msgid "Multiplication sign"
+msgstr "Sinal de multiplicação"
+
+#: ../data/preferences.ui.h:88
+msgid "Division sign"
+msgstr "Sinal de divisão"
+
+#: ../data/preferences.ui.h:89
+msgid "Numbers & Operators"
+msgstr "Números e operadores"
+
+#: ../data/preferences.ui.h:90
+msgid "Use binary prefixes for information units"
+msgstr "Usar prefixos binários para unidades de informações"
+
+#: ../data/preferences.ui.h:91
+msgid ""
+"Use binary, instead of decimal, prefixes by default for information units (e."
+"g. bytes)."
+msgstr ""
+"Usar prefixos binários, em vez de decimais, como padrão para unidades de "
+"informação (ex. bytes)."
+
+#: ../data/preferences.ui.h:92
+msgid "Copy unformatted ASCII without units"
+msgstr "Copiar ASCII não formatado sem unidades"
+
+#: ../data/preferences.ui.h:93
+msgid "Conversion to local currency"
+msgstr "Conversão para moeda local"
+
+#: ../data/preferences.ui.h:94
+msgid ""
+"Automatically convert to the local currency when optimal unit conversion is "
+"activated."
+msgstr ""
+"Converter automaticamente para a moeda local quando a conversão ideal de "
+"unidades estiver ativada."
+
+#: ../data/preferences.ui.h:95
+msgid "Update exchange rates on start"
+msgstr "Atualizar taxas de câmbio ao inicializar"
+
+#: ../data/preferences.ui.h:96
+msgid ""
+"If current exchange rates shall be downloaded from the internet at program "
+"start"
+msgstr ""
+"Para que as taxas de câmbio sejam baixadas da internet no início do programa"
+
+#: ../data/preferences.ui.h:97
+msgid "Exchange rates updates"
+msgstr "Atualizações das taxas de câmbio"
+
+#: ../data/preferences.ui.h:98
+msgid "Temperature calculation mode:"
+msgstr "Modo de cálculo da temperatura:"
+
+#: ../data/preferences.ui.h:99 ../src/callbacks.cc:3091
+msgid "Absolute"
+msgstr "Absoluto"
+
+#: ../data/preferences.ui.h:101 ../src/callbacks.cc:3105
+msgid "Hybrid"
+msgstr "Híbrido"
+
+#: ../data/preferences.ui.h:102
+msgid "Units & Currencies"
+msgstr "Unidades e moedas"
+
+#: ../data/preferences.ui.h:103
+msgid "Show expression completion suggestions"
+msgstr "Mostrar sugestões de preenchimento de expressão"
+
+#: ../data/preferences.ui.h:104
+msgid "Search titles and countries"
+msgstr "Pesquisar títulos e países"
+
+#: ../data/preferences.ui.h:105
+msgid "Minimum characters"
+msgstr "Caracteres mínimos"
+
+#: ../data/preferences.ui.h:106
+msgid "Popup delay (ms)"
+msgstr "Atraso da janela pop-up (ms)"
+
+#: ../data/preferences.ui.h:107
+msgid "Completion"
+msgstr "Preenchimento"
+
+#: ../data/preferences.ui.h:108
+msgid "Custom status font"
+msgstr "Fonte de estado personalizada"
+
+#: ../data/preferences.ui.h:109
+msgid ""
+"If you want to use a font other than the default in the status display below "
+"the expression entry"
+msgstr ""
+"Se desejar usar uma fonte diferente da padrão na exibição de estado abaixo "
+"da entrada da expressão"
+
+#: ../data/preferences.ui.h:110
+msgid "Custom expression font"
+msgstr "Fonte da expressão personalizada"
+
+#: ../data/preferences.ui.h:111
+msgid ""
+"If you want to use a font other than the default in the expression entry"
+msgstr "Se desejar usar uma fonte diferente da padrão na entrada da expressão"
+
+#: ../data/preferences.ui.h:112
+msgid "Custom result font"
+msgstr "Fonte do resultado personalizada"
+
+#: ../data/preferences.ui.h:113
+msgid "If you want to use a font other than the default in the result display"
+msgstr "Se desejar usar uma fonte diferente da padrão na exibição do resultado"
+
+#: ../data/preferences.ui.h:114
+msgid "Custom keypad font"
+msgstr "Fonte do teclado personalizada"
+
+#: ../data/preferences.ui.h:115
+msgid "If you want to use a font other than the default in the keypad"
+msgstr "Se desejar usar uma fonte diferente da padrão no teclado numérico"
+
+#: ../data/preferences.ui.h:116
+msgid "Status warning color"
+msgstr "Cor do estado de erro"
+
+#: ../data/preferences.ui.h:117
+msgid "Status error color"
+msgstr "Cor do estado de erro"
+
+#: ../data/preferences.ui.h:118
+msgid "Text color"
+msgstr "Cor do texto"
+
+#: ../data/preferences.ui.h:119
+msgid "Custom application font"
+msgstr "Fonte do programa personalizada"
+
+#: ../data/preferences.ui.h:120
+msgid ""
+"If you want to use a font other than the default for the whole application"
+msgstr "Se desejar usar uma fonte diferente da padrão em todo o programa"
+
+#: ../data/preferences.ui.h:121
+msgid "Custom history font"
+msgstr "Fonte do histórico personalizado"
+
+#: ../data/preferences.ui.h:122
+msgid "Fonts & Colors"
+msgstr "Fontes e cores"
+
+#: ../data/setbase.ui.h:11
+msgid "Other:"
+msgstr "Outra:"
+
+#: ../data/setbase.ui.h:12 ../src/interface.cc:3724 ../src/interface.cc:3806
+#: ../src/callbacks.cc:30784 ../src/callbacks.cc:30932
+#: ../src/callbacks.cc:31075 ../src/callbacks.cc:31082
+#: ../src/callbacks.cc:31163 ../src/callbacks.cc:31249
+#: ../src/callbacks.cc:31289 ../src/callbacks.cc:31297
+msgid "Bijective base-26"
+msgstr "Base bijetiva-26"
+
+#: ../data/setbase.ui.h:13
+msgid "<b>Result Base</b>"
+msgstr "<b>Resultado da Base</b>"
+
+#: ../data/setbase.ui.h:14
+msgid "<b>Expression Base</b>"
+msgstr "<b>Base de Expressão</b>"
+
+#: ../data/shortcuts.ui.h:6
+msgid "New Keyboard Shortcut"
+msgstr "Novo atalho de teclado"
+
+#: ../data/shortcuts.ui.h:8 ../src/callbacks.cc:37025 ../src/callbacks.cc:37124
+#: ../src/callbacks.cc:37279 ../src/callbacks.cc:37375
+msgid "Add Action"
+msgstr "Adicionar ação"
+
+#: ../data/unitedit.ui.h:1 ../src/callbacks.cc:17012
+msgid "Edit Unit"
+msgstr "Editar Unidade"
+
+#: ../data/unitedit.ui.h:4
+msgid "Do not create/modify this unit"
+msgstr "Não criar/modificar esta unidade"
+
+#: ../data/unitedit.ui.h:6
+msgid "Accept the creation/modification of this unit"
+msgstr "Aceitar a criação/modificação desta unidade"
+
+#: ../data/unitedit.ui.h:10
+msgid "System"
+msgstr "Sistema"
+
+#: ../data/unitedit.ui.h:12
+msgid "Hide unit"
+msgstr "Ocultar unidade"
+
+#: ../data/unitedit.ui.h:13
+msgid "Imperial"
+msgstr "Imperial"
+
+#: ../data/unitedit.ui.h:14
+msgid "US Survey"
+msgstr "US Survey"
+
+#: ../data/unitedit.ui.h:15
+msgid "Title displayed in menus and in unit manager"
+msgstr "Título exibido nos menus e no gestor de unidades"
+
+#: ../data/unitedit.ui.h:16
+msgid "Singular form of this unit's name"
+msgstr "Forma singular do nome desta unidade"
+
+#: ../data/unitedit.ui.h:18
+msgid "Class"
+msgstr "Classe"
+
+#: ../data/unitedit.ui.h:19
+msgid ""
+"The class that this unit belongs to. Named derived units are defined in "
+"relation to a single other unit, with an optional exponent, while (unnamed) "
+"derived units are defined by a unit expression with one or multiple units."
+msgstr ""
+"A classe a que esta unidade pertence. As unidades derivadas nomeadas são "
+"definidas em relação a uma única outra unidade, com um expoente opcional, "
+"enquanto as unidades derivadas (não nomeadas) são definidas por uma "
+"expressão de unidade com uma ou várias unidades."
+
+#: ../data/unitedit.ui.h:20
+msgid "Base unit"
+msgstr "Unidade base"
+
+#: ../data/unitedit.ui.h:21
+msgid "Named derived unit"
+msgstr "Unidade derivada nomeada"
+
+#: ../data/unitedit.ui.h:22
+msgid "Derived unit"
+msgstr "Unidade derivada"
+
+#: ../data/unitedit.ui.h:23
+msgid "Base unit(s)"
+msgstr "Unidade(s) base"
+
+#: ../data/unitedit.ui.h:24
+msgid "Exponent"
+msgstr "Expoente"
+
+#: ../data/unitedit.ui.h:25
+msgid "Relation"
+msgstr "Relação"
+
+#: ../data/unitedit.ui.h:26
+msgid "Inverse relation"
+msgstr "Relação inversa"
+
+#: ../data/unitedit.ui.h:27
+msgid "Mix with base unit"
+msgstr "Mesclar com a unidade base"
+
+#: ../data/unitedit.ui.h:28
+msgid "Priority"
+msgstr "Prioridade"
+
+#: ../data/unitedit.ui.h:29
+msgid "Minimum base unit number"
+msgstr "Número mínimo da unidade base"
+
+#: ../data/unitedit.ui.h:30
+msgid "Exponent of the base unit"
+msgstr "Exponent of the base unit"
+
+#: ../data/unitedit.ui.h:31
+msgid ""
+"Unit (for named derived unit) or unit expression (for unnamed derived unit) "
+"that this unit is defined in relation to"
+msgstr ""
+"Unidade (para unidade derivada designada) ou expressão de unidade (para "
+"unidade derivada não designada) em relação à qual esta unidade é definida"
+
+#: ../data/unitedit.ui.h:32
+msgid ""
+"Relation to the base unit. For linear relations this should just be a "
+"number.\n"
+"\n"
+"For non-linear relations use \\x for the factor and \\y for the exponent (e."
+"g. \"\\x + 273.15\" for the relation between degrees Celsius and Kelvin)."
+msgstr ""
+"Relação com a unidade base. Para relações lineares, isto deve ser apenas um "
+"número.\n"
+"\n"
+"Para relações não-lineares, use \\x para o fator e \\y para o expoente (por "
+"exemplo, \"\\x + 273,15\" para a relação entre graus Celsius e Kelvin)."
+
+#: ../data/unitedit.ui.h:35
+msgid "Specify for non-linear relation, for conversion back to the base unit."
+msgstr ""
+"Específica para relação não-linear, para converter de volta para a unidade "
+"base."
+
+#: ../data/unitedit.ui.h:36
+msgid "Use with prefixes by default"
+msgstr "Use com prefixos por padrão"
+
+#: ../data/units.ui.h:3
+msgid "Convert between units"
+msgstr "Converter entre unidades"
+
+#: ../data/units.ui.h:4
+msgid "="
+msgstr "="
+
+#: ../data/units.ui.h:5
+msgid "Conver_sion"
+msgstr "Conver_são"
+
+#: ../data/units.ui.h:6
+msgid "Converted value"
+msgstr "Valor convertido"
+
+#: ../data/units.ui.h:7
+msgid "Value to convert from"
+msgstr "Valor para converter"
+
+#: ../data/units.ui.h:9
+msgid "_Unit"
+msgstr "_Unidade"
+
+#: ../data/units.ui.h:12
+msgid "Create a new unit"
+msgstr "Criar uma nova unidade"
+
+#: ../data/units.ui.h:14
+msgid "Edit the selected unit"
+msgstr "Editar a unidade selecionada"
+
+#: ../data/units.ui.h:16
+msgid "Delete the selected unit"
+msgstr "Eliminar a unidade selecionada"
+
+#: ../data/units.ui.h:17
+msgid "(De)activate the selected unit"
+msgstr "Desativar a unidade selecionada"
+
+#: ../data/units.ui.h:20
+msgid "Insert the selected unit into the expression entry"
+msgstr "Inserir a unidade selecionada na entrada da expressão"
+
+#: ../data/units.ui.h:21
+msgid "C_onvert"
+msgstr "C_onverter"
+
+#: ../data/units.ui.h:22
+msgid "Convert the result to the selected unit"
+msgstr "Converter o resultado na unidade selecionada"
+
+#: ../data/units.ui.h:23
+msgid "Type anywhere"
+msgstr "Digitar em qualquer lugar"
+
+#: ../data/unknownedit.ui.h:1 ../src/callbacks.cc:17879
+msgid "Edit Unknown Variable"
+msgstr "Editar Variável Desconhecida"
+
+#: ../data/unknownedit.ui.h:6
+msgid "Use custom assumptions"
+msgstr "Usar suposições personalizadas"
+
+#: ../data/unknownedit.ui.h:8
+msgid "Sign"
+msgstr "Sinal"
+
+#: ../data/unknownedit.ui.h:10
+msgid "Real Number"
+msgstr "Número real"
+
+#: ../data/unknownedit.ui.h:11
+msgid "Rational Number"
+msgstr "Número racional"
+
+#: ../data/unknownedit.ui.h:20
+msgid "Name used to reference this unknown variable in expressions"
+msgstr "Nome usado para referenciar esta variável desconhecida em expressões"
+
+#: ../data/variableedit.ui.h:1 ../src/callbacks.cc:18083
+msgid "Edit Variable"
+msgstr "Editar Variável"
+
+#: ../data/variableedit.ui.h:10
+msgid "The category this variable belongs to"
+msgstr "A categoria à qual essa variável pretence"
+
+#: ../data/variables.ui.h:4
+msgid "_Variable"
+msgstr "_Variável"
+
+#: ../data/variables.ui.h:7
+msgid "Create a new variable"
+msgstr "Criar uma nova variável"
+
+#: ../data/variables.ui.h:9
+msgid "Edit the selected variable"
+msgstr "Editar a variável selecionada"
+
+#: ../data/variables.ui.h:11
+msgid "Delete the selected variable"
+msgstr "Eliminar a variável selecionada"
+
+#: ../data/variables.ui.h:12
+msgid "(De)activate the selected variable"
+msgstr "Desativar a variável selecionada"
+
+#: ../data/variables.ui.h:15
+msgid "Insert the selected variable into the expression entry"
+msgstr "Insira a variável selecionada na entrada da expressão"
+
+#: ../data/variables.ui.h:16
+msgid "E_xport"
+msgstr "E_xportar"
+
+#: ../src/main.cc:95
+msgid "Execute expressions and commands from a file"
+msgstr "Executar expressões e comandos a partir de um ficheiro"
+
+#: ../src/main.cc:95
+msgid "FILE"
+msgstr "FICHEIRO"
+
+#: ../src/main.cc:96
+msgid "Start a new instance of the application"
+msgstr "Iniciar uma nova instância do programa"
+
+#: ../src/main.cc:97
+msgid "Display the application version"
+msgstr "Mostrar a versão do programa"
+
+#: ../src/main.cc:98
+msgid "Specify the window title"
+msgstr "Especifica o título da janela"
+
+#: ../src/main.cc:98
+msgid "TITLE"
+msgstr "TÍTULO"
+
+#: ../src/main.cc:99
+msgid "Expression to calculate"
+msgstr "Expressão para calcular"
+
+#: ../src/main.cc:99
+msgid "[EXPRESSION]"
+msgstr "[EXPRESSION]"
+
+#: ../src/main.cc:234
+msgid "ans"
+msgstr "ans"
+
+#: ../src/main.cc:235
+msgid "Last Answer"
+msgstr "Última resposta"
+
+#: ../src/main.cc:236 ../src/callbacks.cc:511
+msgid "answer"
+msgstr "resposta"
+
+#: ../src/main.cc:238
+msgid "Answer 2"
+msgstr "Resposta 2"
+
+#: ../src/main.cc:239
+msgid "Answer 3"
+msgstr "Resposta 3"
+
+#: ../src/main.cc:240
+msgid "Answer 4"
+msgstr "Resposta 4"
+
+#: ../src/main.cc:241
+msgid "Answer 5"
+msgstr "Resposta 5"
+
+#: ../src/main.cc:251
+msgid "Memory"
+msgstr "Memória"
+
+#: ../src/main.cc:263 ../src/searchprovider.cc:669
+#, c-format
+msgid "Failed to load global definitions!\n"
+msgstr "Falha ao carregar definições globais!\n"
+
+#. if no category has been selected (previously selected has been renamed/deleted), select "All"
+#: ../src/main.cc:295 ../src/main.cc:298 ../src/main.cc:301
+#: ../src/callbacks.cc:5270 ../src/callbacks.cc:5340 ../src/callbacks.cc:5377
+#: ../src/callbacks.cc:5648 ../src/callbacks.cc:5719 ../src/callbacks.cc:5757
+#: ../src/callbacks.cc:5930 ../src/callbacks.cc:5999 ../src/callbacks.cc:6051
+#: ../src/callbacks.cc:6234 ../src/callbacks.cc:6290 ../src/callbacks.cc:6475
+msgid "All"
+msgstr "Todas"
+
+#: ../src/main.cc:547
+#, c-format
+msgid ""
+"By default, only one instance (one main window) of %s is allowed.\n"
+"\n"
+"If multiple instances are opened simultaneously, only the definitions "
+"(variables, functions, etc.), mode, preferences, and history of the last "
+"closed window will be saved.\n"
+"\n"
+"Do you, despite this, want to change the default behavior and allow multiple "
+"simultaneous instances?"
+msgstr ""
+"Por padrão, apenas uma instância (uma janela principal) de %s é permitida.\n"
+"\n"
+"Se várias instâncias forem abertas simultaneamente, apenas as definições "
+"(variáveis, funções, etc.), modo, preferências e histórico da última janela "
+"serão guardadas.\n"
+"\n"
+"Mesmo assim, deseja alterar o comportamento padrão e permitir várias "
+"instâncias simultaneamente?"
+
+#: ../src/interface.cc:1138
+#, c-format
+msgid "Right-click/long press: %s"
+msgstr "Botão direito/pressionar e segurar: %s"
+
+#: ../src/interface.cc:1139
+#, c-format
+msgid "Right-click: %s"
+msgstr "Botão direito: %s"
+
+#: ../src/interface.cc:1145
+#, c-format
+msgid "Middle-click: %s"
+msgstr "Botão do meio: %s"
+
+#: ../src/interface.cc:1208 ../src/interface.cc:4476
+msgid "Cycle through previous expression"
+msgstr "Percorrer pela expressão anterior"
+
+#: ../src/interface.cc:1215 ../src/interface.cc:4477
+msgid "Move cursor left or right"
+msgstr "Mover cursor para esquerda ou direita"
+
+#: ../src/interface.cc:1215 ../src/interface.cc:4477
+msgid "Move cursor to beginning or end"
+msgstr "Mover cursor para o início ou fim"
+
+#: ../src/interface.cc:1219 ../src/interface.cc:4479
+msgid "Uncertainty/interval"
+msgstr "Incerteza/intervalo"
+
+#: ../src/interface.cc:1219 ../src/interface.cc:4479
+msgid "Relative error"
+msgstr "Erro relativo"
+
+#: ../src/interface.cc:1220 ../src/interface.cc:4480
+msgid "Argument separator"
+msgstr "Separador de argumentos"
+
+#: ../src/interface.cc:1220 ../src/interface.cc:1235 ../src/interface.cc:4480
+#: ../src/interface.cc:4494
+msgid "Blank space"
+msgstr "Espaço em branco"
+
+#: ../src/interface.cc:1220 ../src/interface.cc:1235 ../src/interface.cc:4480
+#: ../src/interface.cc:4494
+msgid "New line"
+msgstr "Nova linha"
+
+#: ../src/interface.cc:1221 ../src/interface.cc:4481 ../src/callbacks.cc:7179
+#: ../src/callbacks.cc:7427 ../src/callbacks.cc:7430
+msgid "Smart parentheses"
+msgstr "Parênteses inteligentes"
+
+#: ../src/interface.cc:1221 ../src/interface.cc:4481
+msgid "Vector brackets"
+msgstr "Parênteses para vetores"
+
+#: ../src/interface.cc:1223 ../src/interface.cc:4482
+msgid "Left parenthesis"
+msgstr "Parêntese esquerdo"
+
+#: ../src/interface.cc:1223 ../src/interface.cc:4482
+msgid "Left vector bracket"
+msgstr "Parêntese esquerdo do vetor"
+
+#: ../src/interface.cc:1224 ../src/interface.cc:4483
+msgid "Right parenthesis"
+msgstr "Parêntese direito"
+
+#: ../src/interface.cc:1224 ../src/interface.cc:4483
+msgid "Right vector bracket"
+msgstr "Parêntese direito do vetor"
+
+#: ../src/interface.cc:1235 ../src/interface.cc:4494
+msgid "Decimal point"
+msgstr "Ponto decimal"
+
+#: ../src/interface.cc:1250
+msgid "Raise (Ctrl+*)"
+msgstr "Aumentar (Ctrl+*)"
+
+#: ../src/interface.cc:1278 ../src/interface.cc:4501
+msgid "Add"
+msgstr "Adicionar"
+
+#: ../src/interface.cc:1278 ../src/interface.cc:4501 ../src/callbacks.cc:4428
+#: ../src/callbacks.cc:7072 ../src/callbacks.cc:30204
+msgid "M+ (memory plus)"
+msgstr "M+ (memória mais)"
+
+#: ../src/interface.cc:1283 ../src/interface.cc:4505 ../src/callbacks.cc:4422
+#: ../src/callbacks.cc:7069 ../src/callbacks.cc:30201
+msgid "MC (memory clear)"
+msgstr "MC (apagar memória)"
+
+#: ../src/interface.cc:1284 ../src/interface.cc:4506
+msgid "Backspace"
+msgstr "Backspace"
+
+#: ../src/interface.cc:1284 ../src/interface.cc:4506 ../src/callbacks.cc:4431
+#: ../src/callbacks.cc:7073 ../src/callbacks.cc:30205
+msgid "M− (memory minus)"
+msgstr "M− (memória menos)"
+
+#: ../src/interface.cc:1285 ../src/interface.cc:4507
+msgid "Previous result (static)"
+msgstr "Resultado anterior (estático)"
+
+#: ../src/interface.cc:1293 ../src/interface.cc:4508 ../src/callbacks.cc:1755
+#: ../src/callbacks.cc:15800
+msgid "Calculate expression"
+msgstr "Calcular expressão"
+
+#: ../src/interface.cc:1293 ../src/interface.cc:4508 ../src/callbacks.cc:7070
+#: ../src/callbacks.cc:30202
+msgid "MR (memory recall)"
+msgstr "MR (memória de recuperação)"
+
+#: ../src/interface.cc:1293 ../src/interface.cc:4508 ../src/callbacks.cc:4425
+#: ../src/callbacks.cc:7071 ../src/callbacks.cc:30203
+msgid "MS (memory store)"
+msgstr "MS (memória de armazenamento)"
+
+#: ../src/interface.cc:1571 ../src/callbacks.cc:7031
+msgid "Set unknowns"
+msgstr "Definir incógnitos"
+
+#. Show further items in a submenu
+#: ../src/interface.cc:1619 ../src/interface.cc:1707 ../src/interface.cc:1710
+#: ../src/callbacks.cc:7537 ../src/callbacks.cc:7631 ../src/callbacks.cc:25028
+#: ../src/callbacks.cc:29940
+msgid "more"
+msgstr "mais"
+
+#: ../src/interface.cc:1769
+msgid "Logical AND"
+msgstr "Lógico AND"
+
+#: ../src/interface.cc:1770
+msgid "Logical OR"
+msgstr "Lógico OR"
+
+#: ../src/interface.cc:1771
+msgid "Logical NOT"
+msgstr "Lógico NOT"
+
+#: ../src/interface.cc:1773 ../src/interface.cc:1774 ../src/interface.cc:1775
+#: ../src/interface.cc:1776
+msgid "Toggle Result Base"
+msgstr "Alternar base de resultados"
+
+#: ../src/interface.cc:1778
+msgid "Open menu with stored variables"
+msgstr "Abrir menu com variáveis armazenadas"
+
+#: ../src/interface.cc:2433 ../src/interface.cc:2487
+msgid "Index"
+msgstr "Índice"
+
+#. RPN Enter (calculate and add to stack)
+#: ../src/interface.cc:2505 ../src/callbacks.cc:15772
+msgid "ENTER"
+msgstr "ENTER"
+
+#: ../src/interface.cc:2506 ../src/interface.cc:2507 ../src/callbacks.cc:1755
+#: ../src/callbacks.cc:15773
+msgid "Calculate expression and add to stack"
+msgstr "Calcular expressão e adicionar à pilha"
+
+#: ../src/interface.cc:2583 ../src/interface.cc:2816
+msgid "Flag"
+msgstr "Bandeira"
+
+#: ../src/interface.cc:3289 ../src/interface.cc:3552
+msgid "Reference"
+msgstr "Referência"
+
+#: ../src/interface.cc:3542
+msgid "Abbreviation"
+msgstr "Abreviação"
+
+#: ../src/interface.cc:3548
+msgid "Plural"
+msgstr "Plural"
+
+#: ../src/interface.cc:3558
+msgid "Avoid input"
+msgstr "Evitar entrada"
+
+#: ../src/interface.cc:3564
+msgid "Suffix"
+msgstr "Sufixo"
+
+#: ../src/interface.cc:3570
+msgid "Case sensitive"
+msgstr "Maiúsc. e Minúsculas"
+
+#: ../src/interface.cc:3576
+msgid "Completion only"
+msgstr "Apenas preenchimento"
+
+#: ../src/interface.cc:4024
+msgid "Gregorian"
+msgstr "Gregoriano"
+
+#: ../src/interface.cc:4025
+msgid "Revised Julian (Milanković)"
+msgstr "Juliano revisado (Milanković)"
+
+#: ../src/interface.cc:4026
+msgid "Julian"
+msgstr "Juliano"
+
+#: ../src/interface.cc:4027
+msgid "Islamic (Hijri)"
+msgstr "Islâmico (Hijri)"
+
+#: ../src/interface.cc:4028
+msgid "Hebrew"
+msgstr "Hebreu"
+
+#: ../src/interface.cc:4029
+msgid "Chinese"
+msgstr "Chinês"
+
+#: ../src/interface.cc:4030
+msgid "Persian (Solar Hijri)"
+msgstr "Persa (Hijri Solar)"
+
+#: ../src/interface.cc:4031
+msgid "Coptic"
+msgstr "Cóptico"
+
+#: ../src/interface.cc:4032
+msgid "Ethiopian"
+msgstr "Etíope"
+
+#: ../src/interface.cc:4033
+msgid "Indian (National)"
+msgstr "Indiano (Nacional)"
+
+#: ../src/interface.cc:4362 ../src/interface.cc:4385 ../src/interface.cc:4584
+msgid "Action"
+msgstr "Ação"
+
+#: ../src/interface.cc:4371
+msgid "Key combination"
+msgstr "Combinação de teclas"
+
+#: ../src/interface.cc:4498
+msgid "Raise"
+msgstr "Aumentar"
+
+#: ../src/callbacks.cc:510
+msgid "History Answer Value"
+msgstr "Valor da resposta do histórico"
+
+#: ../src/callbacks.cc:514 ../src/callbacks.cc:539
+msgid "History Index(es)"
+msgstr "Índice(s) do histórico"
+
+#: ../src/callbacks.cc:525 ../src/callbacks.cc:550
+#, c-format
+msgid "History index %s does not exist."
+msgstr "O índice do histórico %s não existe."
+
+#: ../src/callbacks.cc:535
+msgid "History Parsed Expression"
+msgstr "Expressão analisada historicamente"
+
+#: ../src/callbacks.cc:536 ../src/callbacks.cc:18932
+msgid "expression"
+msgstr "expressão"
+
+#: ../src/callbacks.cc:560
+msgid "Set Window Title"
+msgstr "Definir título da janela"
+
+#: ../src/callbacks.cc:1259 ../src/callbacks.cc:15710 ../src/callbacks.cc:34913
+#, c-format
+msgid ""
+"Failed to open %s.\n"
+"%s"
+msgstr ""
+"Falha ao abrir %s.\n"
+"%s"
+
+#: ../src/callbacks.cc:1277
+msgid "Could not display help for Qalculate!."
+msgstr "Não foi possível mostrar a ajuda do Qalculate!."
+
+#: ../src/callbacks.cc:1374
+#, c-format
+msgid ""
+"Could not display help for Qalculate!.\n"
+"%s"
+msgstr ""
+"Não foi possível mostrar a ajuda do Qalculate!.\n"
+"%s"
+
+#: ../src/callbacks.cc:1416 ../src/callbacks.cc:5852 ../src/callbacks.cc:8881
+#: ../src/callbacks.cc:11009 ../src/callbacks.cc:11397
+#: ../src/callbacks.cc:11452 ../src/callbacks.cc:11905
+#: ../src/callbacks.cc:12582 ../src/callbacks.cc:12643
+#: ../src/callbacks.cc:16266 ../src/callbacks.cc:28155
+#: ../src/searchprovider.cc:119 ../src/searchprovider.cc:120
+#: ../src/searchprovider.cc:197
+msgid "approx."
+msgstr "aprox."
+
+#: ../src/callbacks.cc:1737
+msgid "Stop process"
+msgstr "Parar processo"
+
+#: ../src/callbacks.cc:1748 ../src/callbacks.cc:26562
+msgid "Clear expression"
+msgstr "Limpar expressão"
+
+#: ../src/callbacks.cc:2300
+msgid "EXACT"
+msgstr "EXACT"
+
+#: ../src/callbacks.cc:2303
+msgid "APPROX"
+msgstr "APPROX"
+
+#: ../src/callbacks.cc:2307
+msgid "RPN"
+msgstr "RPN"
+
+#. Chain mode
+#: ../src/callbacks.cc:2312
+msgid "CHN"
+msgstr "CHN"
+
+#: ../src/callbacks.cc:2340
+msgid "ROMAN"
+msgstr "ROMAN"
+
+#: ../src/callbacks.cc:2397
+msgid "DEG"
+msgstr "DEG"
+
+#: ../src/callbacks.cc:2402
+msgid "RAD"
+msgstr "RAD"
+
+#: ../src/callbacks.cc:2407
+msgid "GRA"
+msgstr "GRA"
+
+#: ../src/callbacks.cc:2414
+msgid "PREC"
+msgstr "VAR"
+
+#: ../src/callbacks.cc:2419
+msgid "FUNC"
+msgstr "FUNC"
+
+#: ../src/callbacks.cc:2425
+msgid "UNIT"
+msgstr "UNIT"
+
+#: ../src/callbacks.cc:2431
+msgid "VAR"
+msgstr "VAR"
+
+#: ../src/callbacks.cc:2437
+msgid "INF"
+msgstr "INF"
+
+#: ../src/callbacks.cc:2443
+msgid "CPLX"
+msgstr "CPLX"
+
+#: ../src/callbacks.cc:2469
+msgid "Do you wish to update the exchange rates now?"
+msgstr "Deseja atualizar as taxas de câmbio agora?"
+
+#: ../src/callbacks.cc:2471
+#, c-format
+msgid "It has been %s day since the exchange rates last were updated."
+msgid_plural "It has been %s days since the exchange rates last were updated."
+msgstr[0] "Faz %s dia desde a última atualização das taxas de câmbio."
+msgstr[1] "Faz %s dias desde a última atualização das taxas de câmbio."
+
+#: ../src/callbacks.cc:2472
+msgid "Do not ask again"
+msgstr "Não perguntar novamente"
+
+#: ../src/callbacks.cc:2529 ../src/callbacks.cc:37838 ../src/callbacks.cc:37849
+#: ../src/callbacks.cc:37860
+msgid "It took too long to generate the plot data."
+msgstr "Demorou muito para gerar os dados da parcela."
+
+#: ../src/callbacks.cc:2529
+msgid ""
+"It took too long to generate the plot data. Please decrease the sampling "
+"rate or increase the time limit in preferences."
+msgstr ""
+"Demorou muito para gerar os dados da parcela. Diminua a taxa de amostragem "
+"ou aumente o limite de tempo nas preferências."
+
+#: ../src/callbacks.cc:2629
+msgid "Exchange rate source:"
+msgid_plural "Exchange rate sources:"
+msgstr[0] "Fonte da taxa de câmbio:"
+msgstr[1] "Fontes da taxa de câmbio:"
+
+#: ../src/callbacks.cc:2631
+#, c-format
+msgid "updated %s"
+msgid_plural "updated %s"
+msgstr[0] "atualizado %s"
+msgstr[1] "atualizados %s"
+
+#: ../src/callbacks.cc:2651
+msgid ""
+"When errors, warnings and other information are generated during "
+"calculation, the icon in the upper right corner of the expression entry "
+"changes to reflect this. If you hold the pointer over or click the icon, the "
+"message will be shown."
+msgstr ""
+"Quando erros, avisos e outras informações são geradas durante o cálculo, o "
+"ícone à direita da entrada da expressão é alterado para mostrar isto. Ao "
+"segurar o ponteiro do rato ou clicar no ícone, a mensagem será exibida."
+
+#: ../src/callbacks.cc:2732
+msgid "Path of executable not found."
+msgstr "Caminho do executável não encontrado."
+
+#: ../src/callbacks.cc:2742
+msgid "curl not found."
+msgstr "curl não encontrado."
+
+#: ../src/callbacks.cc:2800
+#, c-format
+msgid ""
+"Failed to run update script.\n"
+"%s"
+msgstr ""
+"Falha ao executar o script de atualização.\n"
+"%s"
+
+#: ../src/callbacks.cc:2820
+msgid "Failed to check for updates."
+msgstr "Falha ao verificar por atualizações."
+
+#: ../src/callbacks.cc:2820
+msgid "No updates found."
+msgstr "Nenhuma atualização encontrada."
+
+#: ../src/callbacks.cc:2840
+#, c-format
+msgid ""
+"A new version of %s is available at %s.\n"
+"\n"
+"Do you wish to update to version %s?"
+msgstr ""
+"Uma nova versão do %s está disponível em %s.\n"
+"\n"
+"Deseja atualizar para a versão %s?"
+
+#: ../src/callbacks.cc:2842
+#, c-format
+msgid ""
+"A new version of %s is available.\n"
+"\n"
+"You can get version %s at %s."
+msgstr ""
+"Uma nova versão do %s está disponível.\n"
+"\n"
+"Você pode obter a versão %s em %s."
+
+#: ../src/callbacks.cc:2878
+#, c-format
+msgid "Too many arguments for %s()."
+msgstr "Argumentos em excesso para %s()."
+
+#: ../src/callbacks.cc:2906 ../src/callbacks.cc:5457 ../src/callbacks.cc:6710
+msgid "argument"
+msgstr "argumento"
+
+#: ../src/callbacks.cc:3078
+msgid "Temperature Calculation Mode"
+msgstr "Ferramenta de cálculo de percentagem"
+
+#: ../src/callbacks.cc:3088
+msgid ""
+"The expression is ambiguous.\n"
+"Please select temperature calculation mode\n"
+"(the mode can later be changed in preferences)."
+msgstr ""
+"A expressão é ambígua.\n"
+"Selecione o modo de cálculo de temperatura\n"
+"(o modo pode ser alterado mais tarde nas preferências)."
+
+#: ../src/callbacks.cc:3156
+msgid "Sinc Function"
+msgstr "Função Sinc"
+
+#: ../src/callbacks.cc:3166
+msgid "Please select desired variant of the sinc function."
+msgstr "Selecione a variante desejada da função sinc."
+
+#: ../src/callbacks.cc:3169
+msgid "Unnormalized"
+msgstr "Não normalizada"
+
+#: ../src/callbacks.cc:3176
+msgid "Normalized"
+msgstr "Normalizada"
+
+#: ../src/callbacks.cc:3209
+msgid "Interpretation of dots"
+msgstr "Interpretação de pontos"
+
+#: ../src/callbacks.cc:3219
+msgid ""
+"Please select interpretation of dots (\".\")\n"
+"(this can later be changed in preferences)."
+msgstr ""
+"Selecione a interpretação de pontos (\".\")\n"
+"(isto pode ser alterado mais tarde nas preferências)."
+
+#: ../src/callbacks.cc:3222
+msgid "Both dot and comma as decimal separators"
+msgstr "Ponto e vírgula como separadores decimais"
+
+#: ../src/callbacks.cc:3229
+msgid "Dot as thousands separator"
+msgstr "Ponto como separador de milhares"
+
+#: ../src/callbacks.cc:3236
+msgid "Only dot as decimal separator"
+msgstr "Apenas ponto como separador decimal"
+
+#: ../src/callbacks.cc:3288
+msgid ""
+"The expression is ambiguous.\n"
+"Please select interpretation of expressions with implicit multiplication\n"
+"(this can later be changed in preferences)."
+msgstr ""
+"A expressão é ambígua.\n"
+"Selecione a interpretação de expressões com multiplicação implícita\n"
+"(isto pode ser alterado mais tarde nas preferências)."
+
+#: ../src/callbacks.cc:3291
+msgid "Implicit multiplication first"
+msgstr "Primeiro multiplicação implícita"
+
+#: ../src/callbacks.cc:3299
+msgid "Conventional"
+msgstr "Convencional"
+
+#: ../src/callbacks.cc:3355 ../src/callbacks.cc:5324 ../src/callbacks.cc:5325
+#: ../src/callbacks.cc:5379 ../src/callbacks.cc:5703 ../src/callbacks.cc:5704
+#: ../src/callbacks.cc:5759 ../src/callbacks.cc:5983 ../src/callbacks.cc:5984
+#: ../src/callbacks.cc:6053 ../src/callbacks.cc:6281 ../src/callbacks.cc:6282
+#: ../src/callbacks.cc:6283 ../src/callbacks.cc:6477 ../src/callbacks.cc:15681
+#: ../src/callbacks.cc:17299 ../src/callbacks.cc:17786
+#: ../src/callbacks.cc:18009 ../src/callbacks.cc:18257
+#: ../src/callbacks.cc:18566
+msgid "Uncategorized"
+msgstr "Sem categoria"
+
+#: ../src/callbacks.cc:3462 ../src/callbacks.cc:4734 ../src/callbacks.cc:4740
+msgid "fraction"
+msgstr "fração"
+
+#: ../src/callbacks.cc:3619 ../src/callbacks.cc:4604 ../src/callbacks.cc:14968
+msgid "hexadecimal"
+msgstr "hexadecimal"
+
+#: ../src/callbacks.cc:3622 ../src/callbacks.cc:4606 ../src/callbacks.cc:14971
+msgid "octal"
+msgstr "octal"
+
+#: ../src/callbacks.cc:3625 ../src/callbacks.cc:4608 ../src/callbacks.cc:14974
+msgid "decimal"
+msgstr "decimal"
+
+#: ../src/callbacks.cc:3628 ../src/callbacks.cc:4610 ../src/callbacks.cc:14977
+msgid "duodecimal"
+msgstr "duodecimal"
+
+#: ../src/callbacks.cc:3636 ../src/callbacks.cc:4614 ../src/callbacks.cc:14985
+msgid "binary"
+msgstr "binário"
+
+#: ../src/callbacks.cc:3639 ../src/callbacks.cc:4616 ../src/callbacks.cc:14988
+msgid "roman"
+msgstr "romanos"
+
+#: ../src/callbacks.cc:3642 ../src/callbacks.cc:4618 ../src/callbacks.cc:14991
+msgid "bijective"
+msgstr "bijetivo"
+
+#: ../src/callbacks.cc:3648 ../src/callbacks.cc:3651 ../src/callbacks.cc:3654
+#: ../src/callbacks.cc:4622 ../src/callbacks.cc:14997 ../src/callbacks.cc:15000
+#: ../src/callbacks.cc:15003
+msgid "sexagesimal"
+msgstr "sexagesimal"
+
+#: ../src/callbacks.cc:3657 ../src/callbacks.cc:3660 ../src/callbacks.cc:4624
+#: ../src/callbacks.cc:4625 ../src/callbacks.cc:15006 ../src/callbacks.cc:15009
+msgid "latitude"
+msgstr "latitude"
+
+#: ../src/callbacks.cc:3663 ../src/callbacks.cc:3666 ../src/callbacks.cc:4626
+#: ../src/callbacks.cc:4627 ../src/callbacks.cc:15012 ../src/callbacks.cc:15015
+msgid "longitude"
+msgstr "longitude"
+
+#: ../src/callbacks.cc:3684 ../src/callbacks.cc:4638 ../src/callbacks.cc:15033
+msgid "time"
+msgstr "hora"
+
+#: ../src/callbacks.cc:3735 ../src/callbacks.cc:4642 ../src/callbacks.cc:15107
+msgid "bases"
+msgstr "bases"
+
+#: ../src/callbacks.cc:3737 ../src/callbacks.cc:4644 ../src/callbacks.cc:4645
+#: ../src/callbacks.cc:15117
+msgid "calendars"
+msgstr "calendários"
+
+#: ../src/callbacks.cc:3739 ../src/callbacks.cc:4658 ../src/callbacks.cc:15127
+msgid "rectangular"
+msgstr "retangular"
+
+#: ../src/callbacks.cc:3739 ../src/callbacks.cc:4658 ../src/callbacks.cc:15127
+msgid "cartesian"
+msgstr "cartesiano"
+
+#: ../src/callbacks.cc:3743 ../src/callbacks.cc:4660 ../src/callbacks.cc:15140
+msgid "exponential"
+msgstr "exponencial"
+
+#: ../src/callbacks.cc:3747 ../src/callbacks.cc:4662 ../src/callbacks.cc:15153
+msgid "polar"
+msgstr "polar"
+
+#: ../src/callbacks.cc:3755 ../src/callbacks.cc:4666 ../src/callbacks.cc:15179
+msgid "angle"
+msgstr "ângulo"
+
+#: ../src/callbacks.cc:3755 ../src/callbacks.cc:4668 ../src/callbacks.cc:15179
+msgid "phasor"
+msgstr "fasor"
+
+#: ../src/callbacks.cc:3759 ../src/callbacks.cc:4646 ../src/callbacks.cc:15192
+msgid "optimal"
+msgstr "ideal"
+
+#: ../src/callbacks.cc:3764 ../src/callbacks.cc:4648 ../src/callbacks.cc:15204
+msgid "prefix"
+msgstr "prefixo"
+
+#: ../src/callbacks.cc:3768 ../src/callbacks.cc:3784 ../src/callbacks.cc:4650
+#: ../src/callbacks.cc:4723 ../src/callbacks.cc:15208 ../src/callbacks.cc:15255
+msgid "base"
+msgstr "base"
+
+#: ../src/callbacks.cc:3773 ../src/callbacks.cc:4652 ../src/callbacks.cc:15220
+msgid "mixed"
+msgstr "mesclado"
+
+#: ../src/callbacks.cc:3778 ../src/callbacks.cc:4654 ../src/callbacks.cc:4655
+#: ../src/callbacks.cc:15235
+msgid "factors"
+msgstr "fatores"
+
+#: ../src/callbacks.cc:3781 ../src/callbacks.cc:4656 ../src/callbacks.cc:15245
+msgid "partial fraction"
+msgstr "fração parcial"
+
+#: ../src/callbacks.cc:3788 ../src/callbacks.cc:4728 ../src/callbacks.cc:15259
+msgid "decimals"
+msgstr "decimais"
+
+#: ../src/callbacks.cc:3831 ../src/callbacks.cc:4440 ../src/callbacks.cc:4442
+#: ../src/callbacks.cc:15317 ../src/searchprovider.cc:161
+msgid "factorize"
+msgstr "fatorar"
+
+#: ../src/callbacks.cc:3834 ../src/callbacks.cc:4443 ../src/callbacks.cc:4445
+#: ../src/callbacks.cc:15320 ../src/searchprovider.cc:161
+msgid "expand"
+msgstr "expandir"
+
+#: ../src/callbacks.cc:4605 ../src/callbacks.cc:4719
+msgid "hexadecimal number"
+msgstr "número hexadecimal"
+
+#: ../src/callbacks.cc:4607
+msgid "octal number"
+msgstr "número octal"
+
+#: ../src/callbacks.cc:4609
+msgid "decimal number"
+msgstr "número decimal"
+
+#: ../src/callbacks.cc:4611 ../src/callbacks.cc:4613
+msgid "duodecimal number"
+msgstr "número duodecimal"
+
+#: ../src/callbacks.cc:4615 ../src/callbacks.cc:4713
+msgid "binary number"
+msgstr "número binário"
+
+#: ../src/callbacks.cc:4617
+msgid "roman numerals"
+msgstr "numerais romanos"
+
+#: ../src/callbacks.cc:4619
+msgid "bijective base-26"
+msgstr "base bijetiva-26"
+
+#: ../src/callbacks.cc:4621
+msgid "binary-coded decimal"
+msgstr "decimal com código binário"
+
+#: ../src/callbacks.cc:4623
+msgid "sexagesimal number"
+msgstr "número sexagesimal"
+
+#: ../src/callbacks.cc:4629
+msgid "32-bit floating point"
+msgstr "ponto flutuante de 32-bit"
+
+#: ../src/callbacks.cc:4631
+msgid "64-bit floating point"
+msgstr "ponto flutuante de 64-bit"
+
+#: ../src/callbacks.cc:4633
+msgid "16-bit floating point"
+msgstr "ponto flutuante de 16-bit"
+
+#: ../src/callbacks.cc:4635
+msgid "80-bit (x86) floating point"
+msgstr "ponto flutuante de 80-bit (x86)"
+
+#: ../src/callbacks.cc:4637
+msgid "128-bit floating point"
+msgstr "ponto flutuante de 128-bit"
+
+#: ../src/callbacks.cc:4639
+msgid "time format"
+msgstr "formato de hora"
+
+#: ../src/callbacks.cc:4641 ../src/callbacks.cc:8408
+msgid "Unicode"
+msgstr "Unicode"
+
+#: ../src/callbacks.cc:4643
+msgid "number bases"
+msgstr "bases numéricas"
+
+#: ../src/callbacks.cc:4647
+msgid "optimal unit"
+msgstr "unidade ideal"
+
+#: ../src/callbacks.cc:4649
+msgid "optimal prefix"
+msgstr "prefixo ideal"
+
+#: ../src/callbacks.cc:4651
+msgid "base units"
+msgstr "unidades de base"
+
+#: ../src/callbacks.cc:4653
+msgid "mixed units"
+msgstr "unidades mescladas"
+
+#: ../src/callbacks.cc:4657
+msgid "expanded partial fractions"
+msgstr "frações parciais expandidas"
+
+#: ../src/callbacks.cc:4659
+msgid "complex rectangular form"
+msgstr "forma retangular complexa"
+
+#: ../src/callbacks.cc:4661
+msgid "complex exponential form"
+msgstr "forma exponencial complexa"
+
+#: ../src/callbacks.cc:4663
+msgid "complex polar form"
+msgstr "forma polar complexa"
+
+#: ../src/callbacks.cc:4665
+msgid "complex cis form"
+msgstr "forma cis complexa"
+
+#: ../src/callbacks.cc:4667
+msgid "complex angle notation"
+msgstr "notação complexa de ângulo"
+
+#: ../src/callbacks.cc:4669
+msgid "complex phasor notation"
+msgstr "notação complexa de fasor"
+
+#: ../src/callbacks.cc:4671
+msgid "UTC time zone"
+msgstr "Fuso horário UTC"
+
+#: ../src/callbacks.cc:4724
+#, c-format
+msgid "number base %s"
+msgstr "número base %s"
+
+#: ../src/callbacks.cc:4729
+msgid "decimal fraction"
+msgstr "fração decimal"
+
+#: ../src/callbacks.cc:5072
+msgid "My Variables"
+msgstr "Minhas Variáveis"
+
+#: ../src/callbacks.cc:5315 ../src/callbacks.cc:5316 ../src/callbacks.cc:5383
+#: ../src/callbacks.cc:7973 ../src/callbacks.cc:17784 ../src/callbacks.cc:23149
+#: ../src/callbacks.cc:23150
+msgid "User functions"
+msgstr "Funções de utilizador"
+
+#: ../src/callbacks.cc:5333 ../src/callbacks.cc:5334 ../src/callbacks.cc:5381
+#: ../src/callbacks.cc:5712 ../src/callbacks.cc:5713 ../src/callbacks.cc:5761
+#: ../src/callbacks.cc:5991 ../src/callbacks.cc:5992 ../src/callbacks.cc:6055
+#: ../src/callbacks.cc:17295 ../src/callbacks.cc:17782
+#: ../src/callbacks.cc:18005 ../src/callbacks.cc:18253
+#: ../src/callbacks.cc:18562 ../src/callbacks.cc:23151
+#: ../src/callbacks.cc:23152
+msgid "Inactive"
+msgstr "Inativo"
+
+#: ../src/callbacks.cc:5486
+#, c-format
+msgid ""
+"Retrieves data from the %s data set for a given object and property. If "
+"\"info\" is typed as property, a dialog window will pop up with all "
+"properties of the object."
+msgstr ""
+"Recupera dados do conjunto de dados %s para um determinado objeto e "
+"propriedade. Se \"info\" for digitado como propriedade, uma janela de "
+"diálogo será exibida com todas as propriedades do objeto."
+
+#: ../src/callbacks.cc:5498 ../src/callbacks.cc:16773
+msgid "Example:"
+msgstr "Exemplo:"
+
+#. optional argument
+#: ../src/callbacks.cc:5544 ../src/callbacks.cc:16633 ../src/callbacks.cc:16644
+msgid "optional"
+msgstr "opcional"
+
+#. argument default, in description
+#: ../src/callbacks.cc:5548
+msgid "default: "
+msgstr "padrão: "
+
+#: ../src/callbacks.cc:5562
+msgid "Requirement"
+msgstr "Requerimento"
+
+#. indicating that the property is a data set key
+#: ../src/callbacks.cc:5598 ../src/callbacks.cc:6664 ../src/callbacks.cc:18938
+msgid "key"
+msgstr "chave"
+
+#: ../src/callbacks.cc:5619 ../src/callbacks.cc:5902 ../src/callbacks.cc:6211
+#: ../src/callbacks.cc:19992
+msgid "Acti_vate"
+msgstr "Ati_var"
+
+#: ../src/callbacks.cc:5694 ../src/callbacks.cc:5695 ../src/callbacks.cc:5763
+#: ../src/callbacks.cc:7810 ../src/callbacks.cc:18007 ../src/callbacks.cc:18255
+#: ../src/callbacks.cc:18564 ../src/callbacks.cc:23145
+#: ../src/callbacks.cc:23146
+msgid "User variables"
+msgstr "Variáveis de utilizador"
+
+#: ../src/callbacks.cc:5809 ../src/callbacks.cc:16844 ../src/callbacks.cc:16853
+#: ../src/callbacks.cc:18029 ../src/callbacks.cc:33027
+#: ../src/callbacks.cc:33042 ../src/callbacks.cc:33060
+#: ../src/callbacks.cc:33093
+msgid "Variable does not exist anymore."
+msgstr "A variável não existe mais."
+
+#: ../src/callbacks.cc:5836
+msgid "a matrix"
+msgstr "uma matriz"
+
+#: ../src/callbacks.cc:5838
+msgid "a vector"
+msgstr "um vetor"
+
+#: ../src/callbacks.cc:5864 ../src/callbacks.cc:8161
+msgid "positive"
+msgstr "positivo"
+
+#: ../src/callbacks.cc:5865 ../src/callbacks.cc:8162
+msgid "non-positive"
+msgstr "não-positivo"
+
+#: ../src/callbacks.cc:5866 ../src/callbacks.cc:8163
+msgid "negative"
+msgstr "negativo"
+
+#: ../src/callbacks.cc:5867 ../src/callbacks.cc:8164
+msgid "non-negative"
+msgstr "não-negativo"
+
+#: ../src/callbacks.cc:5868 ../src/callbacks.cc:8165
+msgid "non-zero"
+msgstr "diferente de zero"
+
+#: ../src/callbacks.cc:5874 ../src/callbacks.cc:8171
+msgid "integer"
+msgstr "inteiro"
+
+#: ../src/callbacks.cc:5875 ../src/callbacks.cc:8170
+msgid "boolean"
+msgstr "boleano"
+
+#: ../src/callbacks.cc:5876 ../src/callbacks.cc:8172
+msgid "rational"
+msgstr "racional"
+
+#: ../src/callbacks.cc:5877 ../src/callbacks.cc:8173
+msgid "real"
+msgstr "real"
+
+#: ../src/callbacks.cc:5878 ../src/callbacks.cc:8174
+msgid "complex"
+msgstr "complexo"
+
+#: ../src/callbacks.cc:5879 ../src/callbacks.cc:8175 ../src/callbacks.cc:18924
+msgid "number"
+msgstr "número"
+
+#: ../src/callbacks.cc:5880
+msgid "not matrix"
+msgstr "não matriz"
+
+#: ../src/callbacks.cc:5883 ../src/callbacks.cc:8179
+msgid "unknown"
+msgstr "desconhecido"
+
+#: ../src/callbacks.cc:5975 ../src/callbacks.cc:5976 ../src/callbacks.cc:6057
+#: ../src/callbacks.cc:7568 ../src/callbacks.cc:7662 ../src/callbacks.cc:17297
+#: ../src/callbacks.cc:23147 ../src/callbacks.cc:23148
+msgid "User units"
+msgstr "Unidades de utilizador"
+
+#: ../src/callbacks.cc:6680
+msgid "Data Retrieval Function"
+msgstr "Função de Recuperação de Dados"
+
+#: ../src/callbacks.cc:7013
+msgid "Insert function"
+msgstr "Inserir função"
+
+#: ../src/callbacks.cc:7014
+msgid "Insert function (dialog)"
+msgstr "Inserir função (diálogo)"
+
+#: ../src/callbacks.cc:7015
+msgid "Insert variable"
+msgstr "Inserir variável"
+
+#: ../src/callbacks.cc:7016
+msgid "Insert unit"
+msgstr "Inserir unidade"
+
+#: ../src/callbacks.cc:7017
+msgid "Insert text"
+msgstr "Inserir texto"
+
+#: ../src/callbacks.cc:7018
+msgid "Insert date"
+msgstr "Inserir data"
+
+#: ../src/callbacks.cc:7019
+msgid "Insert vector"
+msgstr "Inserir vetor"
+
+#: ../src/callbacks.cc:7020
+msgid "Insert matrix"
+msgstr "Inserir matriz"
+
+#: ../src/callbacks.cc:7021
+msgid "Insert smart parentheses"
+msgstr "Inserir parênteses inteligentes"
+
+#: ../src/callbacks.cc:7022
+msgid "Convert to unit"
+msgstr "Converter em unidade"
+
+#: ../src/callbacks.cc:7023
+msgid "Convert to unit (entry)"
+msgstr "Converter em unidade (entrada)"
+
+#: ../src/callbacks.cc:7024
+msgid "Convert to optimal unit"
+msgstr "Converter em unidade ideal"
+
+#: ../src/callbacks.cc:7025
+msgid "Convert to base units"
+msgstr "Converter em unidades base"
+
+#: ../src/callbacks.cc:7026
+msgid "Convert to optimal prefix"
+msgstr "Converter em prefixo ideal"
+
+#: ../src/callbacks.cc:7027
+msgid "Convert to number base"
+msgstr "Converter em número base"
+
+#: ../src/callbacks.cc:7028
+msgid "Factorize result"
+msgstr "Fatorar resultado"
+
+#: ../src/callbacks.cc:7029
+msgid "Expand result"
+msgstr "Expandir resultado"
+
+#: ../src/callbacks.cc:7030
+msgid "Expand partial fractions"
+msgstr "Expandir frações parciais"
+
+#: ../src/callbacks.cc:7032
+msgid "RPN: down"
+msgstr "RPN: para baixo"
+
+#: ../src/callbacks.cc:7033
+msgid "RPN: up"
+msgstr "RPN: para cima"
+
+#: ../src/callbacks.cc:7034
+msgid "RPN: swap"
+msgstr "RPN: trocar"
+
+#: ../src/callbacks.cc:7035
+msgid "RPN: copy"
+msgstr "RPN: copiar"
+
+#: ../src/callbacks.cc:7036
+msgid "RPN: lastx"
+msgstr "RPN: lastx"
+
+#: ../src/callbacks.cc:7037
+msgid "RPN: delete register"
+msgstr "RPN: eliminar registo"
+
+#: ../src/callbacks.cc:7038
+msgid "RPN: clear stack"
+msgstr "RPN: limpar pilha"
+
+#: ../src/callbacks.cc:7039
+msgid "Load meta mode"
+msgstr "Carregar modo meta"
+
+#: ../src/callbacks.cc:7040
+msgid "Set expression base"
+msgstr "Definir base de expressão"
+
+#: ../src/callbacks.cc:7041
+msgid "Set result base"
+msgstr "Definir base de resultados"
+
+#: ../src/callbacks.cc:7042
+msgid "Toggle exact mode"
+msgstr "Alternar modo exato"
+
+#: ../src/callbacks.cc:7043
+msgid "Set angle unit to degrees"
+msgstr "Definir unidade de ângulo em graus"
+
+#: ../src/callbacks.cc:7044
+msgid "Set angle unit to radians"
+msgstr "Definir unidade de ângulo em radianos"
+
+#: ../src/callbacks.cc:7045
+msgid "Set angle unit to gradians"
+msgstr "Definir unidade de ângulo em gradianos"
+
+#: ../src/callbacks.cc:7046
+msgid "Toggle simple fractions"
+msgstr "Alternar frações simples"
+
+#: ../src/callbacks.cc:7047
+msgid "Toggle mixed fractions"
+msgstr "Alternar frações mescladas"
+
+#: ../src/callbacks.cc:7048
+msgid "Toggle scientific notation"
+msgstr "Alternar notação científica"
+
+#: ../src/callbacks.cc:7049
+msgid "Toggle simple notation"
+msgstr "Alternar notação simples"
+
+#: ../src/callbacks.cc:7050
+msgid "Toggle precision"
+msgstr "Alternar precisão"
+
+#: ../src/callbacks.cc:7051
+msgid "Toggle max decimals"
+msgstr "Alternar decimais máximos"
+
+#: ../src/callbacks.cc:7052
+msgid "Toggle min decimals"
+msgstr "Alternar decimais mínimos"
+
+#: ../src/callbacks.cc:7053
+msgid "Toggle max/min decimals"
+msgstr "Alternar decimais máximos/mínimos"
+
+#: ../src/callbacks.cc:7054
+msgid "Toggle RPN mode"
+msgstr "Alternar modo RPN"
+
+#: ../src/callbacks.cc:7055
+msgid "Toggle calculate as you type"
+msgstr "Alternar para calcular ao digitar"
+
+#: ../src/callbacks.cc:7056
+msgid "Toggle programming keypad"
+msgstr "Alternar teclado de programação"
+
+#: ../src/callbacks.cc:7057
+msgid "Show keypad"
+msgstr "Mostrar teclado"
+
+#: ../src/callbacks.cc:7058
+msgid "Show history"
+msgstr "Mostrar histórico"
+
+#: ../src/callbacks.cc:7059
+msgid "Search history"
+msgstr "Pesquisar no histórico"
+
+#: ../src/callbacks.cc:7060
+msgid "Clear history"
+msgstr "Limpar histórico"
+
+#: ../src/callbacks.cc:7061
+msgid "Show conversion"
+msgstr "Mostrar conversão"
+
+#: ../src/callbacks.cc:7062
+msgid "Show RPN stack"
+msgstr "Mostrar pilha RPN"
+
+#: ../src/callbacks.cc:7064
+msgid "Manage variables"
+msgstr "Gerenciar variáveis"
+
+#: ../src/callbacks.cc:7065
+msgid "Manage functions"
+msgstr "Gerenciar funções"
+
+#: ../src/callbacks.cc:7067
+msgid "Manage data sets"
+msgstr "Gerenciar conjuntos de dados"
+
+#: ../src/callbacks.cc:7074
+msgid "New variable"
+msgstr "Nova variável"
+
+#: ../src/callbacks.cc:7075
+msgid "New function"
+msgstr "Nova função"
+
+#: ../src/callbacks.cc:7076
+msgid "Open plot functions/data"
+msgstr "Abrir funções/dados de parcela"
+
+#: ../src/callbacks.cc:7077
+msgid "Open convert number bases"
+msgstr "Abrir números base convertidos"
+
+#: ../src/callbacks.cc:7078
+msgid "Open floating point conversion"
+msgstr "Abrir conversão de ponto flutuante"
+
+#: ../src/callbacks.cc:7079
+msgid "Open calendar conversion"
+msgstr "Abrir conversão de calendário"
+
+#: ../src/callbacks.cc:7080
+msgid "Open percentage calculation tool"
+msgstr "Abrir ferramenta de cálculo de percentagem"
+
+#: ../src/callbacks.cc:7081
+msgid "Open periodic table"
+msgstr "Abrir tabela periódica"
+
+#: ../src/callbacks.cc:7082
+msgid "Update exchange rates"
+msgstr "Atualizar taxas de câmbio"
+
+#: ../src/callbacks.cc:7083
+msgid "Copy result"
+msgstr "Copiar resultado"
+
+#: ../src/callbacks.cc:7084
+msgid "Insert result"
+msgstr "Inserir resultado"
+
+#: ../src/callbacks.cc:7085
+msgid "Save result image"
+msgstr "Gravar imagem do resultado"
+
+#: ../src/callbacks.cc:7086
+msgid "Help"
+msgstr "Ajuda"
+
+#: ../src/callbacks.cc:7087
+msgid "Quit"
+msgstr "Sair"
+
+#: ../src/callbacks.cc:7088
+msgid "Toggle chain mode"
+msgstr "Alternar modo de cadeia"
+
+#: ../src/callbacks.cc:7089
+msgid "Toggle keep above"
+msgstr "Alternar manter acima"
+
+#: ../src/callbacks.cc:7090
+msgid "Show/hide completion"
+msgstr "Mostrar/ocultar preenchimento"
+
+#: ../src/callbacks.cc:7091
+msgid "Perform completion (activate first item)"
+msgstr "Efetuar o preenchimento (ativar o primeiro item)"
+
+#: ../src/callbacks.cc:7132
+msgid "Formatted result"
+msgstr "Resultado formatado"
+
+#: ../src/callbacks.cc:7133
+msgid "Unformatted ASCII result"
+msgstr "Resultado ASCII não formatado"
+
+#: ../src/callbacks.cc:7134
+msgid "Unformatted ASCII result without units"
+msgstr "Resultado ASCII não formatado sem unidades"
+
+#: ../src/callbacks.cc:7135
+msgid "Formatted expression"
+msgstr "Expressão formatada"
+
+#: ../src/callbacks.cc:7136
+msgid "Unformatted ASCII expression"
+msgstr "Expressão ASCII não formatada"
+
+#: ../src/callbacks.cc:7137
+msgid "Formatted expression + result"
+msgstr "Expressão formatada + resultado"
+
+#: ../src/callbacks.cc:7138
+msgid "Unformatted ASCII expression + result"
+msgstr "Expressão ASCII não formatada + resultado"
+
+#: ../src/callbacks.cc:7576
+msgid "Prefixes"
+msgstr "Prefixos"
+
+#: ../src/callbacks.cc:7865
+msgid "No Prefix"
+msgstr "Nenhum prefixo"
+
+#: ../src/callbacks.cc:7866 ../src/callbacks.cc:8398
+msgid "Optimal Prefix"
+msgstr "Prefixo ideal"
+
+#: ../src/callbacks.cc:8125
+msgid "a previous result"
+msgstr "um resultado anterior"
+
+#: ../src/callbacks.cc:8138
+msgid "matrix"
+msgstr "matriz"
+
+#: ../src/callbacks.cc:8140
+msgid "vector"
+msgstr "vetor"
+
+#: ../src/callbacks.cc:8176
+msgid "(not matrix)"
+msgstr "(não matriz)"
+
+#: ../src/callbacks.cc:8181
+msgid "default assumptions"
+msgstr "suposições padrão"
+
+#: ../src/callbacks.cc:8321 ../src/callbacks.cc:8325 ../src/callbacks.cc:8329
+msgid "Prefix"
+msgstr "Prefixo"
+
+#: ../src/callbacks.cc:8345
+msgid "Base Units"
+msgstr "Unidade base"
+
+#: ../src/callbacks.cc:8348
+msgid "Binary-Coded Decimal"
+msgstr "Decimal com código binário"
+
+#: ../src/callbacks.cc:8350
+msgid "Bijective Base-26"
+msgstr "Base bijetiva-26"
+
+#: ../src/callbacks.cc:8352
+msgid "Binary Number"
+msgstr "Número binário"
+
+#: ../src/callbacks.cc:8354
+msgid "Calendars"
+msgstr "Calendários"
+
+#: ../src/callbacks.cc:8356
+msgid "Complex cis Form"
+msgstr "Forma cis complexa"
+
+#: ../src/callbacks.cc:8358
+msgid "Decimal Number"
+msgstr "Número decimal"
+
+#: ../src/callbacks.cc:8360
+msgid "Duodecimal Number"
+msgstr "Número duodecimal"
+
+#: ../src/callbacks.cc:8364
+msgid "Factors"
+msgstr "Fatores"
+
+#: ../src/callbacks.cc:8366
+msgid "16-bit Floating Point Binary Format"
+msgstr "Formato binário de ponto flutuante de 16-bit"
+
+#: ../src/callbacks.cc:8368
+msgid "32-bit Floating Point Binary Format"
+msgstr "Formato binário de ponto flutuante de 32-bit"
+
+#: ../src/callbacks.cc:8370
+msgid "64-bit Floating Point Binary Format"
+msgstr "Formato binário de ponto flutuante de 64-bit"
+
+#: ../src/callbacks.cc:8372
+msgid "80-bit (x86) Floating Point Binary Format"
+msgstr "Formato binário de ponto flutuante de 80-bit (x86)"
+
+#: ../src/callbacks.cc:8374
+msgid "128-bit Floating Point Binary Format"
+msgstr "Formato binário de ponto flutuante de 128-bit"
+
+#: ../src/callbacks.cc:8382
+msgid "Hexadecimal Number"
+msgstr "Número hexadecimal"
+
+#: ../src/callbacks.cc:8384
+msgid "Latitude"
+msgstr "Latitude"
+
+#: ../src/callbacks.cc:8386
+msgid "Longitude"
+msgstr "Longitude"
+
+#: ../src/callbacks.cc:8388
+msgid "Mixed Units"
+msgstr "Unidades mistas"
+
+#: ../src/callbacks.cc:8390
+msgid "Octal Number"
+msgstr "Número octal"
+
+#: ../src/callbacks.cc:8392
+msgid "Optimal Units"
+msgstr "Unidades ideais"
+
+#: ../src/callbacks.cc:8394
+msgid "Expanded Partial Fractions"
+msgstr "Frações parciais expandidas"
+
+#: ../src/callbacks.cc:8404
+msgid "Sexagesimal Number"
+msgstr "Número sexagesimal"
+
+#: ../src/callbacks.cc:8410
+msgid "UTC Time Zone"
+msgstr "Fuso horário UTC"
+
+#: ../src/callbacks.cc:10072
+msgid "and"
+msgstr "e"
+
+#: ../src/callbacks.cc:10075 ../src/callbacks.cc:11583
+#: ../src/callbacks.cc:11618 ../src/callbacks.cc:11619
+msgid "or"
+msgstr "ou"
+
+#: ../src/callbacks.cc:10925
+msgid "undefined"
+msgstr "indefinido"
+
+#: ../src/callbacks.cc:11260 ../src/callbacks.cc:36144
+msgid ""
+"result is too long\n"
+"see history"
+msgstr ""
+"resultado é muito longo\n"
+"ver histórico"
+
+#: ../src/callbacks.cc:11283 ../src/callbacks.cc:36165
+msgid "calculation was aborted"
+msgstr "cálculo abortado"
+
+#: ../src/callbacks.cc:12200 ../src/callbacks.cc:28124
+msgid "RPN Register Moved"
+msgstr "Registo RPN movido"
+
+#: ../src/callbacks.cc:12208 ../src/callbacks.cc:15564
+#: ../src/callbacks.cc:28130
+msgid "RPN Operation"
+msgstr "Operação RPN"
+
+#: ../src/callbacks.cc:12423
+msgid "Processing…"
+msgstr "Processando…"
+
+#: ../src/callbacks.cc:12443 ../src/callbacks.cc:36144
+msgid "result processing was aborted"
+msgstr "processamento de resultado abortado"
+
+#: ../src/callbacks.cc:12924
+msgid "Factorizing…"
+msgstr "Fatorando…"
+
+#: ../src/callbacks.cc:12928
+msgid "Expanding partial fractions…"
+msgstr "Expandindo frações parciais…"
+
+#: ../src/callbacks.cc:12932
+msgid "Expanding…"
+msgstr "Expandindo…"
+
+#: ../src/callbacks.cc:12937 ../src/callbacks.cc:15500
+msgid "Calculating…"
+msgstr "Calculando…"
+
+#: ../src/callbacks.cc:12941
+msgid "Converting…"
+msgstr "Convertendo…"
+
+#: ../src/callbacks.cc:13045
+msgid "Fetching exchange rates."
+msgstr "Buscando taxas de câmbio."
+
+#: ../src/callbacks.cc:15084
+msgid "Time zone parsing failed."
+msgstr "Falha na análise do fuso horário."
+
+#: ../src/callbacks.cc:16415
+msgid "Keep open"
+msgstr "Manter aberto"
+
+#. RPN Enter (calculate and add to stack)
+#: ../src/callbacks.cc:16424
+msgid "Enter"
+msgstr "Enter"
+
+#: ../src/callbacks.cc:16424
+msgid "C_alculate"
+msgstr "C_alcular"
+
+#: ../src/callbacks.cc:16427
+msgid "Apply to Stack"
+msgstr "Aplicar à pilha"
+
+#: ../src/callbacks.cc:16486
+msgid "Argument"
+msgstr "Argumento"
+
+#: ../src/callbacks.cc:16541
+msgid "True"
+msgstr "Verdadeiro"
+
+#: ../src/callbacks.cc:16543
+msgid "False"
+msgstr "Falso"
+
+#: ../src/callbacks.cc:16588
+msgid "Info"
+msgstr "Informação"
+
+#: ../src/callbacks.cc:17014
+msgid "Edit Unit (global)"
+msgstr "Editar unidade (global)"
+
+#: ../src/callbacks.cc:17016
+msgid "New Unit"
+msgstr "Nova unidade"
+
+#: ../src/callbacks.cc:17151 ../src/callbacks.cc:17694
+#: ../src/callbacks.cc:17953 ../src/callbacks.cc:18190
+#: ../src/callbacks.cc:18467 ../src/callbacks.cc:19002
+#: ../src/callbacks.cc:19171 ../src/callbacks.cc:19289
+#: ../src/callbacks.cc:21036
+msgid "Empty name field."
+msgstr "Campo de nome vazio."
+
+#: ../src/callbacks.cc:17158 ../src/callbacks.cc:17960
+#: ../src/callbacks.cc:18203 ../src/callbacks.cc:18474
+#: ../src/callbacks.cc:19295
+msgid ""
+"A unit or variable with the same name already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+"Uma unidade ou variável com o mesmo nome já existe.\n"
+"Deseja sobrescrevê-la?"
+
+#: ../src/callbacks.cc:17185 ../src/callbacks.cc:17237
+msgid "Base unit does not exist."
+msgstr "A unidade base não existe."
+
+#: ../src/callbacks.cc:17622
+msgid "Edit Function (global)"
+msgstr "Editar Função (global)"
+
+#: ../src/callbacks.cc:17624
+msgid "New Function"
+msgstr "Nova Função"
+
+#: ../src/callbacks.cc:17709
+msgid "Empty expression field."
+msgstr "Campo de expressão vazio."
+
+#: ../src/callbacks.cc:17719 ../src/callbacks.cc:19183
+msgid ""
+"A function with the same name already exists.\n"
+"Do you want to overwrite the function?"
+msgstr ""
+"Uma função com o mesmo nome já existe.\n"
+"Deseja substituir a função?"
+
+#: ../src/callbacks.cc:17837 ../src/callbacks.cc:17851
+msgid "Unit does not exist"
+msgstr "A unidade não existe"
+
+#: ../src/callbacks.cc:17881
+msgid "Edit Unknown Variable (global)"
+msgstr "Editar Variável Desconhecida (global)"
+
+#: ../src/callbacks.cc:17883
+msgid "New Unknown Variable"
+msgstr "Nova variável desconhecida"
+
+#: ../src/callbacks.cc:18085
+msgid "Edit Variable (global)"
+msgstr "Editar Variáveis (global)"
+
+#: ../src/callbacks.cc:18087
+msgid "New Variable"
+msgstr "Nova Variável"
+
+#: ../src/callbacks.cc:18197
+msgid "Empty value field."
+msgstr "Campo de valor vazio."
+
+#: ../src/callbacks.cc:18310
+msgid "Edit Vector"
+msgstr "Editar Vetor"
+
+#: ../src/callbacks.cc:18312
+msgid "Edit Vector (global)"
+msgstr "Editar Vetor (global)"
+
+#: ../src/callbacks.cc:18314
+msgid "New Vector"
+msgstr "Novo Vetor"
+
+#: ../src/callbacks.cc:18321
+msgid "Edit Matrix (global)"
+msgstr "Editar Matriz (global)"
+
+#: ../src/callbacks.cc:18323
+msgid "New Matrix"
+msgstr "Nova Matriz"
+
+#: ../src/callbacks.cc:18647
+msgid "Vector Result"
+msgstr "Resultado do Vetor"
+
+#: ../src/callbacks.cc:18649
+msgid "Matrix Result"
+msgstr "Resultado da Matriz"
+
+#: ../src/callbacks.cc:18811
+msgid "New Data Object"
+msgstr "Novo Objeto de Dados"
+
+#: ../src/callbacks.cc:18916
+msgid "text"
+msgstr "texto"
+
+#: ../src/callbacks.cc:18921 ../src/callbacks.cc:18929
+msgid "approximate"
+msgstr "aproximado"
+
+#: ../src/callbacks.cc:19094
+msgid "Edit Data Set (global)"
+msgstr "Editar Conjunto de Dados (global)"
+
+#: ../src/callbacks.cc:19096
+msgid "New Data Set"
+msgstr "Novo conjunto de dados"
+
+#: ../src/callbacks.cc:19214
+msgid "Property"
+msgstr "Propriedade"
+
+#: ../src/callbacks.cc:19281 ../src/callbacks.cc:19381
+msgid "No file name entered."
+msgstr "Nenhum nome de ficheiro digitado."
+
+#: ../src/callbacks.cc:19326 ../src/callbacks.cc:19410
+msgid "No delimiter selected."
+msgstr "Nenhum delimitador selecionado."
+
+#: ../src/callbacks.cc:19331
+#, c-format
+msgid ""
+"Could not import from file \n"
+"%s"
+msgstr ""
+"Não foi possível importar do ficheiro \n"
+"%s"
+
+#: ../src/callbacks.cc:19423
+msgid "No variable name entered."
+msgstr "Nenhum nome de variável digitado."
+
+#: ../src/callbacks.cc:19435
+msgid "No known variable with entered name found."
+msgstr "Nenhuma variável conhecida com o nome digitado encontrada."
+
+#: ../src/callbacks.cc:19442
+#, c-format
+msgid ""
+"Could not export to file \n"
+"%s"
+msgstr ""
+"Não foi possível exportar para o ficheiro \n"
+"%s"
+
+#: ../src/callbacks.cc:19493 ../src/callbacks.cc:19512
+#: ../src/callbacks.cc:19521 ../src/callbacks.cc:36763
+msgid ""
+"A conflicting object with the same name exists. If you proceed and save "
+"changes, the conflicting object will be overwritten or deactivated."
+msgstr ""
+"Existe um objeto em conflito com o mesmo nome. Se prosseguir e gravar as "
+"alterações, o objeto em conflito será substituído ou desativado."
+
+#: ../src/callbacks.cc:20143
+msgid "Couldn't write definitions"
+msgstr "Não foi possível gravar definições"
+
+#: ../src/callbacks.cc:20145 ../src/callbacks.cc:20147
+#: ../src/callbacks.cc:22477 ../src/callbacks.cc:22479
+msgid "Ignore"
+msgstr "Ignorar"
+
+#: ../src/callbacks.cc:20145 ../src/callbacks.cc:22477
+msgid "Cancel"
+msgstr "Cancelar"
+
+#: ../src/callbacks.cc:20145 ../src/callbacks.cc:20147
+#: ../src/callbacks.cc:22477 ../src/callbacks.cc:22479
+msgid "Retry"
+msgstr "Tentar novamente"
+
+#: ../src/callbacks.cc:20240 ../src/callbacks.cc:21255
+msgid "Preset"
+msgstr "Predefinição"
+
+#: ../src/callbacks.cc:20483
+msgid "Clear History"
+msgstr "Limpar histórico"
+
+#: ../src/callbacks.cc:20487
+msgid "Abort"
+msgstr "Abortar"
+
+#: ../src/callbacks.cc:20490
+msgid "Undo"
+msgstr "Desfazer"
+
+#: ../src/callbacks.cc:20493
+msgid "Redo"
+msgstr "Refazer"
+
+#: ../src/callbacks.cc:20498
+msgid "Completion Mode"
+msgstr "Modo de preenchimento"
+
+#: ../src/callbacks.cc:20511
+msgid "Limited strict completion"
+msgstr "Preenchimento rigoroso limitado"
+
+#: ../src/callbacks.cc:20512
+msgid "Strict completion"
+msgstr "Preenchimento rigoroso"
+
+#: ../src/callbacks.cc:20513
+msgid "Limited full completion"
+msgstr "Preenchimento total limitado"
+
+#: ../src/callbacks.cc:20514
+msgid "Full completion"
+msgstr "Preenchimento total"
+
+#: ../src/callbacks.cc:20515
+msgid "No completion"
+msgstr "Sem preenchimento"
+
+#: ../src/callbacks.cc:20524
+msgid "Delayed completion"
+msgstr "Preenchimento atrasado"
+
+#: ../src/callbacks.cc:20526
+msgid "Customize completion…"
+msgstr "Personalizar o preenchimento…"
+
+#: ../src/callbacks.cc:21012
+msgid "Save Mode"
+msgstr "Gravar modo"
+
+#: ../src/callbacks.cc:21040
+msgid "Preset mode cannot be overwritten."
+msgstr "O modo predefinido não pode ser substituído."
+
+#: ../src/callbacks.cc:21068
+msgid "Delete Mode"
+msgstr "Eliminar modo"
+
+#: ../src/callbacks.cc:22475
+#, c-format
+msgid ""
+"Couldn't write preferences to\n"
+"%s"
+msgstr ""
+"Não foi possível gravar preferências em\n"
+"%s"
+
+#: ../src/callbacks.cc:24073 ../src/callbacks.cc:24086
+msgid "never"
+msgstr "nunca"
+
+#: ../src/callbacks.cc:24074 ../src/callbacks.cc:24088
+msgid "ask"
+msgstr "perguntar"
+
+#: ../src/callbacks.cc:24082
+#, c-format
+msgid "%i day"
+msgid_plural "%i days"
+msgstr[0] "%i dia"
+msgstr[1] "%i dias"
+
+#: ../src/callbacks.cc:24224
+msgid "Please restart the program for the language change to take effect."
+msgstr "Reinicie o programa para que a alteração de idioma tenha efeito."
+
+#. Result was copied
+#: ../src/callbacks.cc:25402
+msgid "Copied"
+msgstr "Copiado"
+
+#: ../src/callbacks.cc:27807
+msgid "log10 function not found."
+msgstr "função log10 não encontrada."
+
+#: ../src/callbacks.cc:28709
+msgid "Search"
+msgstr "Pesquisar"
+
+#: ../src/callbacks.cc:28709
+msgid "_Search"
+msgstr "_Pesquisar"
+
+#: ../src/callbacks.cc:28729 ../src/callbacks.cc:28985
+msgid "Remove Bookmark"
+msgstr "Remover marcador"
+
+#: ../src/callbacks.cc:28783
+msgid "Add Bookmark"
+msgstr "Adicionar marcador"
+
+#: ../src/callbacks.cc:28809
+msgid ""
+"A bookmark with the selected name already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+"Um marcador com o nome selecionado já existe.\n"
+"Você deseja sobrescrevê-lo?"
+
+#: ../src/callbacks.cc:29004
+msgid "No items found"
+msgstr "Nenhum item encontrado"
+
+#: ../src/callbacks.cc:29387 ../src/callbacks.cc:36358
+msgid "Select date"
+msgstr "Selecionar data"
+
+#: ../src/callbacks.cc:30054
+msgid "All functions"
+msgstr "Todas as funções"
+
+#: ../src/callbacks.cc:30106
+msgid "All variables"
+msgstr "Todas as variáveis"
+
+#: ../src/callbacks.cc:30421 ../src/callbacks.cc:30423
+msgid "Select definitions file"
+msgstr "Selecionar ficheiro de definições"
+
+#: ../src/callbacks.cc:30421 ../src/callbacks.cc:30423
+msgid "_Import"
+msgstr "_Importar"
+
+#: ../src/callbacks.cc:30427
+msgid "XML Files"
+msgstr "Ficheiros XML"
+
+#: ../src/callbacks.cc:30447
+#, c-format
+msgid "Could not copy %s to %s."
+msgstr "Não foi possível copiar %s para %s."
+
+#: ../src/callbacks.cc:30455
+#, c-format
+msgid "Could not read %s."
+msgstr "Não foi possível ler %s."
+
+#: ../src/callbacks.cc:30463
+#, c-format
+msgid "Could not copy file to %s."
+msgstr "Não foi possível copiar o ficheiro para %s."
+
+#: ../src/callbacks.cc:31103 ../src/callbacks.cc:31184
+#: ../src/callbacks.cc:31265 ../src/callbacks.cc:31313
+#: ../src/callbacks.cc:37098 ../src/callbacks.cc:37349
+#: ../src/callbacks.cc:37543
+msgid "Unsupported base."
+msgstr "Base não suportada."
+
+#: ../src/callbacks.cc:31512
+msgid "The selected Chinese year does not exist."
+msgstr "O ano chinês selecionado não existe."
+
+#: ../src/callbacks.cc:31524
+msgid "Conversion to Gregorian calendar failed."
+msgstr "A conversão para o calendário gregoriano falhou."
+
+#: ../src/callbacks.cc:31549
+#, c-format
+msgid "Calendar conversion failed for: %s."
+msgstr "Falha na conversão do calendário para: %s."
+
+#: ../src/callbacks.cc:31586
+msgid "Gnuplot was not found."
+msgstr "Gnuplot não encontrado."
+
+#: ../src/callbacks.cc:31588
+#, c-format
+msgid ""
+"%s (%s) needs to be installed separately, and found in the executable search "
+"path, for plotting to work."
+msgstr ""
+"%s (%s) precisa ser instalado separadamente e localizado no caminho de "
+"pesquisa do executável para que a parcela funcione."
+
+#: ../src/callbacks.cc:32378 ../src/callbacks.cc:32380
+msgid "Select file to save PNG image to"
+msgstr "Selecione o ficheiro para gravar a imagem PNG"
+
+#: ../src/callbacks.cc:32385 ../src/callbacks.cc:37759
+msgid "Allowed File Types"
+msgstr "Tipos de ficheiro permitidos"
+
+#: ../src/callbacks.cc:32390 ../src/callbacks.cc:37770
+msgid "All Files"
+msgstr "Todos os ficheiros"
+
+#. do not delete units that are used by other units
+#: ../src/callbacks.cc:32981
+msgid "Cannot delete unit as it is needed by other units."
+msgstr ""
+"Não é possível eliminar a unidade, pois é necessária para outras unidades."
+
+#: ../src/callbacks.cc:33443 ../src/callbacks.cc:33674
+msgid "none"
+msgstr "nenhum"
+
+#: ../src/callbacks.cc:33999 ../src/callbacks.cc:34000
+#: ../src/callbacks.cc:34001 ../src/callbacks.cc:34002
+#: ../src/callbacks.cc:34015
+msgid "result is too long"
+msgstr "resultado é muito longo"
+
+#: ../src/callbacks.cc:34887
+msgid "translator-credits"
+msgstr "Hugo Carvalho <hugokarvalho@hotmail.com>"
+
+#: ../src/callbacks.cc:35296 ../src/callbacks.cc:37086
+#: ../src/callbacks.cc:37337 ../src/callbacks.cc:37531
+msgid "Mode not found."
+msgstr "Modo não encontrado."
+
+#: ../src/callbacks.cc:36248
+msgid ""
+"Type a mathematical expression above, e.g. \"5 + 2 / 3\",\n"
+"and press the enter key."
+msgstr ""
+"Digite a expressão matemática acima, ex. \"5 + 2 / 3\"\n"
+"e pressione a tecla Enter."
+
+#: ../src/callbacks.cc:36269 ../src/callbacks.cc:36277
+msgid "Elements (in horizontal order)"
+msgstr "Elementos (em ordem horizontal)"
+
+#: ../src/callbacks.cc:36291 ../src/callbacks.cc:36293
+msgid "Select file to import"
+msgstr "Selecionar ficheiro para importar"
+
+#: ../src/callbacks.cc:36291 ../src/callbacks.cc:36293
+#: ../src/callbacks.cc:36329 ../src/callbacks.cc:36331
+#: ../src/callbacks.cc:36401 ../src/callbacks.cc:36403
+msgid "_Open"
+msgstr "_Abrir"
+
+#: ../src/callbacks.cc:36329 ../src/callbacks.cc:36331
+msgid "Select file to export to"
+msgstr "Selecionar o ficheiro para o qual exportar"
+
+#: ../src/callbacks.cc:36401 ../src/callbacks.cc:36403
+msgid "Select file"
+msgstr "Selecionar um ficheiro"
+
+#: ../src/callbacks.cc:36760
+msgid "Illegal name"
+msgstr "Nome ilegal"
+
+#: ../src/callbacks.cc:36976
+msgid "Set key combination"
+msgstr "Definir combinação de teclas"
+
+#. Make the line reasonably long, but not to short (at least around 40 characters)
+#: ../src/callbacks.cc:36980
+msgid ""
+"Press the key combination you wish to use for the action\n"
+"(press Escape to cancel)."
+msgstr ""
+"Pressione a combinação de teclas que deseja usar para a ação\n"
+"(pressione Escape para cancelar)."
+
+#: ../src/callbacks.cc:36990
+msgid "No keys"
+msgstr "Sem teclas"
+
+#: ../src/callbacks.cc:37046 ../src/callbacks.cc:37297
+#: ../src/callbacks.cc:37490
+msgid "Empty value."
+msgstr "Valor vazio."
+
+#: ../src/callbacks.cc:37055 ../src/callbacks.cc:37306
+#: ../src/callbacks.cc:37500
+msgid "Function not found."
+msgstr "Função não encontrada."
+
+#: ../src/callbacks.cc:37063 ../src/callbacks.cc:37314
+#: ../src/callbacks.cc:37508
+msgid "Variable not found."
+msgstr "Variável não encontrada."
+
+#: ../src/callbacks.cc:37071 ../src/callbacks.cc:37322
+#: ../src/callbacks.cc:37516
+msgid "Unit not found."
+msgstr "Unidade não encontrada."
+
+#: ../src/callbacks.cc:37110 ../src/callbacks.cc:37361
+#: ../src/callbacks.cc:37555
+msgid "Unsupported value."
+msgstr "Valor não suportado."
+
+#: ../src/callbacks.cc:37138 ../src/callbacks.cc:37206
+msgid ""
+"The key combination is already in use.\n"
+"Do you wish to replace the current action?"
+msgstr ""
+"A combinação de teclas já está em uso.\n"
+"Deseja substituir a ação atual?"
+
+#: ../src/callbacks.cc:37752 ../src/callbacks.cc:37754
+msgid "Select file to export"
+msgstr "Selecionar ficheiro para exportar"
+
+#: ../src/callbacks.cc:37883 ../src/callbacks.cc:37966
+msgid "Empty expression."
+msgstr "Expressão vazia."
+
+#: ../src/callbacks.cc:37897 ../src/callbacks.cc:37980
+msgid "Empty x variable."
+msgstr "Variável x vazia."
+
+#: ../src/callbacks.cc:38213
+msgid "Element Data"
+msgstr "Dados do elemento"
+
+#: ../src/callbacks.cc:38251
+msgid "Classification"
+msgstr "Classificação"
+
+#: ../src/callbacks.cc:38256
+msgid "Alkali Metal"
+msgstr "Metal alcalino"
+
+#: ../src/callbacks.cc:38257
+msgid "Alkaline-Earth Metal"
+msgstr "Metal alcalino-terroso"
+
+#: ../src/callbacks.cc:38258
+msgid "Lanthanide"
+msgstr "Lantanídeo"
+
+#: ../src/callbacks.cc:38259
+msgid "Actinide"
+msgstr "Actinídeo"
+
+#: ../src/callbacks.cc:38260
+msgid "Transition Metal"
+msgstr "Metal de transição"
+
+#: ../src/callbacks.cc:38261
+msgid "Metal"
+msgstr "Metal"
+
+#: ../src/callbacks.cc:38262
+msgid "Metalloid"
+msgstr "Metaloide"
+
+#: ../src/callbacks.cc:38263
+msgid "Polyatomic Non-Metal"
+msgstr "Não-metal poliatómico"
+
+#: ../src/callbacks.cc:38264
+msgid "Diatomic Non-Metal"
+msgstr "Não-metal diatómico"
+
+#: ../src/callbacks.cc:38265
+msgid "Noble Gas"
+msgstr "Gás nobre"
+
+#: ../src/callbacks.cc:38266
+msgid "Unknown chemical properties"
+msgstr "Propriedades químicas desconhecidas"
+
+#: ../src/callbacks.cc:38391
+msgid "No unknowns in result."
+msgstr "Não há incógnitas no resultado."
+
+#: ../src/callbacks.cc:38397
+msgid "Set Unknowns"
+msgstr "Definir incógnitas"
+
+#: ../src/searchprovider.cc:239
+msgid "Copy result to clipboard"
+msgstr "Copiar resultado para a área de transferência"


### PR DESCRIPTION
@hanna-kn I've added the translation as `pt_PT` but Portuguese also has the lang code `pt`

For now I have only translated the `gtk` version but soon I will also translate the `qt` version