### PR TITLE
searchprovider: don't use conflicting type for simplified_percentage

### DIFF
--- a/src/searchprovider.cc
+++ b/src/searchprovider.cc
@@ -366,7 +366,7 @@ void load_preferences_search() {
 	search_ignore_locale = false;
 	search_adaptive_interval_display = true;
 
-	bool simplified_percentage = true;
+	int simplified_percentage = 1;
 
 	CALCULATOR->useIntervalArithmetic(true);
 	CALCULATOR->useBinaryPrefixes(0);


### PR DESCRIPTION
Fixes the following warning with LTO:
```
interface.cc:186:13: error: type of 'simplified_percentage' does not match original declaration [-Werror=lto-type-mismatch]
  186 | extern bool simplified_percentage;
      |             ^
callbacks.cc:231:5: note: type 'int' should match type 'bool'
  231 | int simplified_percentage = -1;
      |     ^
```

Bug: https://bugs.gentoo.org/940927