### PR TITLE
Grep extraction fix

### DIFF
--- a/data/pkg/update
+++ b/data/pkg/update
@@ -25,7 +25,7 @@ oldversion=`"$bindir/qalc" -v`;
 mkdir -p $tmpdir;
 if cd "$tmpdir"; then
 	if curl -L -o "CURRENT_VERSIONS" https://qalculate.github.io/CURRENT_VERSIONS; then
-		newversion=`grep libqalculate CURRENT_VERSIONS`;
+		newversion=`grep -m 1 libqalculate CURRENT_VERSIONS`;
 		newversion=${newversion##*:}
 		url=`grep linux-x86_64-selfcontained CURRENT_VERSIONS`;
 		url=${url#*:}


### PR DESCRIPTION
Added `-m 1` to line 28 so grep only grabs the first match of `libqalculate` in `CURRENT_VERSIONS`, because otherwise it grabs every match, and line 29 ends up setting `newversion` to `//github.com/Qalculate/libqalculate/releases/download/v5.9.0/qalculate-5.9.0b-x64.msi`