### PR TITLE
Fix PLATFORM_MACOS not being set on macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,7 +54,7 @@ esac
 
 AM_CONDITIONAL(PLATFORM_LINUX, test "$build_linux" = "yes")
 AM_CONDITIONAL(PLATFORM_WIN32, test "$build_windows" = "yes")
-AM_CONDITIONAL(PLATFORM_MACOS, test "$build_macos" = "yes")
+AM_CONDITIONAL(PLATFORM_MACOS, test "$build_mac" = "yes")
 
 dnl  --------------------------------
 dnl | check for neccessary libraries |-----------------------------------------


### PR DESCRIPTION
Due to `PLATFORM_MACOS` never being set on macOS, the compiler include flags for `gtk-mac-integration` never get passed leading to:

```
main.cc:24:11: fatal error: 'gtkosxapplication.h' file not found
   24 | # include <gtkosxapplication.h>
```